### PR TITLE
Kernel support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -174,7 +174,9 @@ nixgg/
 │   ├── go.mod                  no external deps; stdlib only
 │   └── internal/               (listed below)
 ├── bin/nixgg                   built static ELF (git-ignored)
-├── shims/                      symlinks: cc, gcc, c++, g++, ar, ranlib, ld → ../bin/nixgg
+├── shims/                      symlinks: cc, gcc, c++, g++, ar, ranlib,
+│                               ld, ld.bfd, ld.gold, ld.lld, objtool,
+│                               objcopy, rustc → ../bin/nixgg
 ├── nix/
 │   ├── builder.nix             per-TU CA derivation (native mode)
 │   ├── linker.nix              link CA derivation (native mode)

--- a/examples/kmod/default.nix
+++ b/examples/kmod/default.nix
@@ -1,0 +1,197 @@
+# An out-of-tree Linux kernel module through nixgg, in two phases.
+#
+# WHY THIS EXISTS
+#
+# It is the cheapest possible probe of "can nixgg accelerate a kbuild
+# build?", which is the question standing between this project and the
+# NixOS kernel. A full kernel is ~10-20k TUs and a 30-minute failure
+# loop; this is 2 TUs and seconds.
+#
+# It works: `nix build .#kmod` produces a loadable hello_mod.ko with the
+# right vermagic, from two per-TU content-addressed derivations.
+#
+# Getting here required two fixes to nixgg itself, both of which were
+# latent bugs rather than kernel-specific special-casing — see
+# internal/scan's StripWpDep and internal/shim's writeDepFile. Any build
+# system that passes `-Wp,-MMD,<file>` (kbuild does, on every compile)
+# was silently losing its ENTIRE header list, because that flag
+# redirects dependency output to a file and so leaves the scanner's
+# `gcc -M -MG -MF -` with empty stdout.
+#
+# THE OBSTACLE IT WORKS AROUND
+#
+# A single-phase `make modules` through the shims does NOT work, and the
+# reason generalises to the whole kernel: **kbuild reads the bytes of
+# every object it produces, inside the same make run.** nixgg's central
+# bet is that a compile output can stay an unresolved drvref stub until
+# Nix realises it later. kbuild breaks that bet three times per module:
+#
+#   1. objtool, in the same rule as the compile
+#      (scripts/Makefile.build's `$(call if_changed_rule,cc_o_c)`),
+#      fails with `gelf_getehdr failed: invalid 'Elf' handle` —
+#      it is reading a stub, not an ELF file.
+#   2. modpost, which reads each object's symbol table to synthesise
+#      the module's .mod.c. Given a stub it derives no module at all,
+#      and __modfinal then reports `No rule to make target
+#      'hello_mod.ko'`.
+#   3. the `ld -r` that fuses the parts into the .ko.
+#
+# (1) and (2) were both observed directly, in that order. To reproduce:
+# point `objects` at `modules` instead, i.e. do the whole build in
+# phase 1.
+#
+# THE SPLIT
+#
+# Phase 1 compiles the translation units and stops. Phase 2 does
+# everything that needs to read object bytes, by which point Nix has
+# realised phase 1's outputs into real store paths.
+#
+# Two pieces of kbuild machinery make the boundary land exactly where
+# it needs to, rather than requiring us to fight kbuild:
+#
+#   - Building `main.o helper.o` rather than `modules` triggers kbuild's
+#     own single-target mode (`single-targets := … %.o …` in the top
+#     Makefile), which sets single-build=1 and skips the modpost goal.
+#   - hello_mod is deliberately a MULTI-object module. This kernel is
+#     built with CONFIG_X86_KERNEL_IBT=y, so `delay-objtool := y`, and
+#     Makefile.build's `objtool-enabled = $(if $(is-standard-object),
+#     $(if $(delay-objtool),$(is-single-obj-m),y))` therefore runs
+#     objtool per-TU only for SINGLE-object modules. Splitting the
+#     module across two TUs moves objtool to the multi-obj link — i.e.
+#     into phase 2, on real objects. A one-file module cannot be built
+#     this way; it would need option (a) below.
+#
+# Phase 1 hands the whole tree over rather than a single artifact,
+# because phase 2 needs more than the objects: kbuild's `if_changed`
+# compares the recorded command line in each `.<obj>.o.cmd` against the
+# command it would run now, and a missing .cmd means "rebuild". So the
+# handoff has to carry the .cmd files too. That is exactly what `nixgg
+# assemble` already does for dynDrvStdenv's phase 1 — walk the tree,
+# resolve every stub, submit the whole thing as one output — so this
+# reuses it rather than inventing a second mechanism.
+#
+# WHAT THIS DOES NOT SOLVE
+#
+# The multi-object trick is a property of MODULE builds. It does not
+# carry over to vmlinux's own built-in objects — but, on this kernel's
+# config, it turns out not to need to: kbuild already defers objtool for
+# built-ins on its own. scripts/Makefile.vmlinux_o says so directly —
+# "For delay-objtool (IBT or LTO), objtool doesn't run on individual
+# translation units. Instead it runs on vmlinux.o." NixOS builds with
+# CONFIG_X86_KERNEL_IBT=y, and CONFIG_FTRACE_MCOUNT_USE_CC=y means
+# -mrecord-mcount replaces the separate recordmcount pass too. So for
+# ordinary built-in objects the per-TU pipeline is just compile+fixdep,
+# both of which nixgg now handles.
+#
+# What this example does NOT cover, and what a real kernel hits next:
+# built-in.a is a THIN archive at every level of the tree
+# (scripts/Makefile.build's `cmd_ar_builtin` → `$(AR) cDPrST`), whose
+# members are recorded as paths rather than bytes; and that ar runs
+# under `xargs`, which splits into multiple appending invocations once a
+# directory has enough objects — a shape internal/shim/archive.go
+# explicitly does not model ("every archive we build is fresh").
+{
+  mkNixggBuild,
+  stdenv,
+  kernel,
+  kmod,
+  src,
+}:
+
+let
+  kdir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  # Kept as bindings because the assemble call below has to reproduce
+  # mkNixggBuild's own naming exactly; spelling either out twice would
+  # rot the moment one changed.
+  partsPname = "nixgg-kmod-parts";
+  partsTarget = "modtree";
+
+  # Phase 1 — accelerated. Every cc invocation becomes its own
+  # content-addressed derivation, exactly as in every other example.
+  parts = mkNixggBuild {
+    pname = partsPname;
+    version = kernel.modDirVersion;
+    inherit src;
+
+    # Never matched by any link/archive shim: `nixgg assemble` owns the
+    # single submit-output call for this derivation, and a per-artifact
+    # submit racing it would be wrong. Same reasoning as dynDrvStdenv's
+    # NIXGG_SANDBOX_TARGET=/nonexistent/…, just spelled differently
+    # because mkNixggBuild derives its drv name from `targets`.
+    targets = [ { name = partsTarget; path = partsTarget; } ];
+
+    nativeBuildInputs = [ kmod ];
+
+    # kernel.dev must be a real buildInput, not merely interpolated into
+    # buildCommand below. mkNixggBuild derives NIXGG_KNOWN_STORE_PATHS
+    # from buildInputs ++ propagatedBuildInputs, and storedeps.From only
+    # promotes a /nix/store path into a per-TU drv's inputs.srcs if it
+    # matches that list. kbuild's compile line carries
+    # `-I<kernel-dev>/…/source/include` and
+    # `-include <kernel-dev>/…/compiler-version.h`; without this the
+    # inner drvs build in a sandbox where none of that exists and fail
+    # with `compiler-version.h: No such file or directory`. Same failure
+    # mode the zlib/ncurses `-dev`-output note on knownStorePathInputs
+    # in nix/mkNixggBuild.nix describes.
+    buildInputs = [ kernel.dev ];
+
+    # The assemble name and output key must agree with what
+    # submit-output enforces: the submitted drv has to be named
+    # outputPathName(<outer name>, <output key>), which is the outer
+    # derivation's name plus "-" plus the key minus its ".drv" suffix.
+    # mkNixggBuild names the outer derivation "nixgg-${pname}" and
+    # declares one output per entry in `targets`, keyed "<name>.drv" —
+    # there is no "out" output at all, so `nixgg assemble` has to be
+    # told the key explicitly or it fails with "submitted unknown
+    # output 'out'".
+    buildCommand = ''
+      make objects KDIR=${kdir}
+      nixgg assemble "$NIX_BUILD_TOP" "nixgg-${partsPname}-${partsTarget}" "${partsTarget}.drv"
+    '';
+  };
+
+  # Phase 2 — deliberately NOT accelerated, and a plain derivation
+  # rather than a second mkNixggBuild. Everything left to do reads
+  # object bytes, which is precisely what the shims cannot serve; there
+  # is nothing here for them to speed up.
+  module = stdenv.mkDerivation {
+  pname = "nixgg-kmod";
+  version = kernel.modDirVersion;
+  dontUnpack = true;
+  nativeBuildInputs = [ kmod ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # phase 1's tree, with every stub replaced by its realised artifact.
+    cp -a ${parts.result}/. .
+    chmod -R u+w .
+    cd mod
+
+    make modules KDIR=${kdir}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/extra"
+    cp hello_mod.ko "$out/lib/modules/${kernel.modDirVersion}/extra/"
+
+      runHook postInstall
+    '';
+  };
+in
+{
+  # Same shape every other example returns, so flake.nix's exampleDefs
+  # mapAttrs picks it up unchanged: `.package` is the thing to build,
+  # `.shell` mirrors the accelerated phase's stdenv env.
+  inherit (parts) drv shell result;
+  package = module;
+  # Phase 1 on its own, so the accelerated half can be built and
+  # inspected without running phase 2 — same reason examples/two-phase
+  # exposes `codegen` and examples/llvm exposes its tblgen phases.
+  inherit parts;
+}

--- a/examples/kmod/mod/Makefile
+++ b/examples/kmod/mod/Makefile
@@ -1,0 +1,29 @@
+# Out-of-tree module, built in two passes so that the steps which READ
+# object bytes happen after Nix has realised them. See ../default.nix.
+#
+# KDIR comes from the caller (default.nix points it at
+# ${kernel.dev}/lib/modules/<ver>/build).
+
+obj-m += hello_mod.o
+hello_mod-y := main.o helper.o
+
+KDIR ?= $(error KDIR must point at a prepared kernel build tree)
+PWD  := $(shell pwd)
+
+# Phase 1: compile the parts and nothing else. These are kbuild
+# "single targets" (top Makefile's `single-targets := … %.o …`), which
+# sets single-build=1 and so skips the modpost goal entirely. Because
+# hello_mod is a multi-object module, objtool is not run on these
+# either — it is deferred to the multi-obj link in phase 2.
+objects:
+	$(MAKE) -C $(KDIR) M=$(PWD) main.o helper.o
+
+# Phase 2: everything that needs to read real object bytes — the
+# multi-obj `ld -r`, objtool, modpost, and modfinal.
+modules:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+
+.PHONY: objects modules clean

--- a/examples/kmod/mod/helper.c
+++ b/examples/kmod/mod/helper.c
@@ -1,0 +1,14 @@
+// The second translation unit. Its only job is to make hello_mod a
+// MULTI-object module, which is load-bearing — see default.nix: with
+// CONFIG_X86_KERNEL_IBT (hence delay-objtool), kbuild runs objtool on
+// the per-TU object only for single-object modules. Two TUs push
+// objtool to the multi-obj link step, which is the phase boundary this
+// example splits on.
+
+#include <linux/kernel.h>
+#include "helper.h"
+
+int nixgg_helper_value(void)
+{
+	return 42;
+}

--- a/examples/kmod/mod/helper.h
+++ b/examples/kmod/mod/helper.h
@@ -1,0 +1,6 @@
+#ifndef NIXGG_HELPER_H
+#define NIXGG_HELPER_H
+
+int nixgg_helper_value(void);
+
+#endif /* NIXGG_HELPER_H */

--- a/examples/kmod/mod/main.c
+++ b/examples/kmod/mod/main.c
@@ -1,0 +1,27 @@
+// Minimal out-of-tree kernel module, split across two translation
+// units on purpose (see helper.c).
+
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+#include "helper.h"
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("nixgg out-of-tree kbuild smoke module");
+MODULE_VERSION("0");
+
+static int __init hello_mod_init(void)
+{
+	pr_info("nixgg: hello from an out-of-tree module (%d)\n",
+		nixgg_helper_value());
+	return 0;
+}
+
+static void __exit hello_mod_exit(void)
+{
+	pr_info("nixgg: goodbye\n");
+}
+
+module_init(hello_mod_init);
+module_exit(hello_mod_exit);

--- a/examples/rustc/Makefile
+++ b/examples/rustc/Makefile
@@ -1,0 +1,29 @@
+RUSTC ?= rustc
+AR ?= ar
+RUSTFLAGS ?= --edition=2021 -Cdebuginfo=0 -Ccodegen-units=1
+
+all: libapp.a
+
+# rustc's @-file format is one argument per line, verbatim — not the
+# compiler drivers' whitespace-and-quotes tokenisation. Nothing else in
+# the suite covers the difference, and getting it wrong killed a kernel
+# build on its first rustc call.
+cfg.args:
+	printf -- '--cfg=feature_from_argfile\n' > $@
+
+# One invocation, two artifacts: the object, and the metadata `app`
+# resolves --extern against. A grouped target (&:) because that is what
+# actually happens — without it make may run the recipe twice.
+dep.o libdep.rmeta &: dep/lib.rs
+	$(RUSTC) $(RUSTFLAGS) --crate-type=rlib --crate-name=dep \
+	  --emit=obj=dep.o --emit=metadata=libdep.rmeta dep/lib.rs
+
+app.o: app/main.rs app/gen.rs libdep.rmeta cfg.args
+	$(RUSTC) $(RUSTFLAGS) @cfg.args --crate-type=rlib --crate-name=app \
+	  --extern dep=libdep.rmeta --emit=obj=app.o app/main.rs
+
+libapp.a: app.o dep.o
+	$(AR) rcs $@ app.o dep.o
+
+clean:
+	rm -f app.o dep.o libdep.rmeta libapp.a cfg.args

--- a/examples/rustc/app/gen.rs
+++ b/examples/rustc/app/gen.rs
@@ -1,0 +1,3 @@
+// Reached only through include!, so nothing but rustc's own dep-info
+// can report it — see scan.RunRust.
+pub const EXTRA: u32 = 5;

--- a/examples/rustc/app/main.rs
+++ b/examples/rustc/app/main.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+include!("gen.rs");
+
+// The cfg comes from an @-argfile. rustc's argfile format is one
+// argument per line, verbatim — tokenising it the compiler-driver way
+// mangles the value and the cfg silently never arrives. Fail loudly
+// instead: a silent miss here is exactly the bug this guards.
+#[cfg(not(feature_from_argfile))]
+compile_error!("--cfg from the @-argfile did not reach rustc");
+
+pub fn total() -> u32 {
+    dep::value() + EXTRA
+}

--- a/examples/rustc/default.nix
+++ b/examples/rustc/default.nix
@@ -1,0 +1,40 @@
+# A two-crate Rust build driven by make and bare rustc — the shape
+# kbuild uses, and the only shape the rustc shim models.
+#
+# Deliberately not cargo. Cargo drives rustc through its own protocol
+# and picks the compiler from a toolchain file rather than PATH, so a
+# shim never sees the invocation. A build system that calls rustc
+# directly does, which is what this covers.
+#
+# What it exercises that nothing else does:
+#
+#   - one invocation, two artifacts. `dep` emits both an object and the
+#     .rmeta that `app` resolves --extern against, and both become
+#     drvref stubs pointing at the same derivation.
+#   - a crate compiled against a dependency that is a STUB. The
+#     dependency scan runs while libdep.rmeta is a drvref stub rather
+#     than a loadable crate, which is the normal case under nixgg and
+#     the reason scan.RunRust ignores rustc's exit status.
+#   - `include!`, which no preprocessor-style scanner can see.
+#   - an @-argfile, whose format is rustc's own and not the compiler
+#     drivers'. app/main.rs fails to compile if the cfg it carries goes
+#     missing, so a regression there is loud rather than silent.
+#   - the ar shim over rustc-produced stubs.
+#
+# Not in tests/drv-equivalence.sh, and not an oversight: the rustc shim
+# is sandbox-only, so native mode runs rustc for real and produces no
+# derivations to compare against. There is no equivalence to pin.
+{
+  mkNixggBuild,
+  rustc,
+  src,
+}:
+
+mkNixggBuild {
+  pname = "rustc-example";
+  version = "0";
+  inherit src;
+  targets = [ { name = "libapp"; path = "libapp.a"; } ];
+  nativeBuildInputs = [ rustc ];
+  buildCommand = "make -j\"$NIX_BUILD_CORES\"";
+}

--- a/examples/rustc/dep/lib.rs
+++ b/examples/rustc/dep/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub const fn value() -> u32 {
+    37
+}

--- a/flake.nix
+++ b/flake.nix
@@ -283,7 +283,7 @@
               # rewriter, reached only when a caller points the build's
               # `objtool=` make variable here (nothing resolves it via
               # PATH). Linked anyway so that pointing at it works.
-              for t in ar c++ cc g++ gcc ranlib clang clang++ ld ld.bfd ld.gold ld.lld objtool objcopy; do
+              for t in ar c++ cc g++ gcc ranlib clang clang++ ld ld.bfd ld.gold ld.lld objtool objcopy rustc; do
                 ln -s ../bin/nixgg $out/shims/$t
               done
               for t in gcc g++ cc c++ ar ranlib ld; do

--- a/flake.nix
+++ b/flake.nix
@@ -882,6 +882,18 @@
               dir = ./examples/linux-kernel;
               args = { inherit (pkgs) stdenv flex bison elfutils pkg-config bc; src = linux-src; };
             };
+            # Out-of-tree kernel module — the cheap kbuild probe that
+            # stands in for the NixOS kernel. See its docstring for
+            # what it does and does not cover. Not in smoke.sh's QUICK
+            # set until it passes.
+            kmod = {
+              dir = ./examples/kmod;
+              args = {
+                inherit (pkgs) kmod stdenv;
+                kernel = pkgs.linuxPackages.kernel;
+                src = ./examples/kmod/mod;
+              };
+            };
             # Two sources, no single `src`: phase 1 builds the codegen
             # tool, phase 2 execs it mid-build. Smoke test for the
             # phase-chaining pattern examples/llvm relies on.

--- a/flake.nix
+++ b/flake.nix
@@ -1001,10 +1001,31 @@
           # shape directly.
           exampleResults = builtins.mapAttrs (_: e: e.package) examples;
           exampleShells = pkgs.lib.mapAttrs' (n: e: pkgs.lib.nameValuePair "${n}-shell" e.shell) examples;
+
+          # `.#<name>-shared` is the same example definition with
+          # sharedStaging flipped on — staged source trees become symlink
+          # farms into per-file store objects instead of per-TU copies.
+          #
+          # Generated rather than hand-written so these cannot drift from
+          # the definitions above, and wrapped at the mkNixggBuild seam so
+          # each example keeps its own args untouched.
+          #
+          # These exist for tests/shared-closure.sh, which has to build for
+          # real: the property it checks (that `nix store add --scan`
+          # records symlink targets as references) is unobservable outside
+          # a recursive-nix builder. They are ordinary derivations, so
+          # they are also the way to try shared staging on any example.
+          sharedExamples = pkgs.lib.mapAttrs'
+            (n: def: pkgs.lib.nameValuePair "${n}-shared"
+              (import def.dir ({
+                mkNixggBuild = args: mkNixggBuild (args // { sharedStaging = true; });
+              } // def.args)).package)
+            exampleDefs;
         in
         toolchain
         // exampleResults   # .#hello .#lua .#fmt .#mosh .#redis .#ffmpeg .#gcc .#two-phase .#llvm
         // exampleShells    # .#<name>-shell for each of the above
+        // sharedExamples   # .#<name>-shared: same, with sharedStaging on
         // dynDrvExamples   # .#hello-dyndrv .#mosh-dyndrv .#zstd-dyndrv
         // configureCacheExamples   # .#hello-cache .#zstd-cache .#hello-cache-filtered .#fmt-cache-filtered
         // dynDrvConfigureCacheExamples   # .#hello-dyndrv-configure-cached .#mosh-dyndrv-configure-cached .#zstd-dyndrv-configure-cached .#gdbm-dyndrv-configure-cached

--- a/flake.nix
+++ b/flake.nix
@@ -283,7 +283,7 @@
               # rewriter, reached only when a caller points the build's
               # `objtool=` make variable here (nothing resolves it via
               # PATH). Linked anyway so that pointing at it works.
-              for t in ar c++ cc g++ gcc ranlib clang clang++ ld ld.bfd ld.gold ld.lld objtool; do
+              for t in ar c++ cc g++ gcc ranlib clang clang++ ld ld.bfd ld.gold ld.lld objtool objcopy; do
                 ln -s ../bin/nixgg $out/shims/$t
               done
               for t in gcc g++ cc c++ ar ranlib ld; do

--- a/flake.nix
+++ b/flake.nix
@@ -897,6 +897,16 @@
             # Two sources, no single `src`: phase 1 builds the codegen
             # tool, phase 2 execs it mid-build. Smoke test for the
             # phase-chaining pattern examples/llvm relies on.
+            # Two Rust crates built by make and bare rustc — the shape
+            # kbuild uses, and the only one the rustc shim models. See
+            # its docstring for what it covers that nothing else does.
+            rustc = {
+              dir = ./examples/rustc;
+              args = {
+                inherit (pkgs) rustc;
+                src = ./examples/rustc;
+              };
+            };
             two-phase = {
               dir = ./examples/two-phase;
               args = {

--- a/flake.nix
+++ b/flake.nix
@@ -279,7 +279,11 @@
               # triples and versions is unbounded. These cover what the
               # examples and common autotools/cmake probes actually
               # invoke; add more if a real project needs them.
-              for t in ar c++ cc g++ gcc ranlib clang clang++ ld ld.bfd ld.gold ld.lld; do
+              # objtool is not a compiler: it is a per-object
+              # rewriter, reached only when a caller points the build's
+              # `objtool=` make variable here (nothing resolves it via
+              # PATH). Linked anyway so that pointing at it works.
+              for t in ar c++ cc g++ gcc ranlib clang clang++ ld ld.bfd ld.gold ld.lld objtool; do
                 ln -s ../bin/nixgg $out/shims/$t
               done
               for t in gcc g++ cc c++ ar ranlib ld; do

--- a/go/internal/assemble/assemble.go
+++ b/go/internal/assemble/assemble.go
@@ -168,6 +168,24 @@ func copyRecursive(src, dst string) error {
 			}
 		}
 		return nil
+	case drvref.Is(src):
+		// A drvref stub's whole content is a /nix/store/….drv path, and
+		// `nix store add --scan` records every store path it finds. So
+		// copying stubs verbatim makes the captured tree REFERENCE each
+		// producing derivation, and a derivation's closure includes its
+		// own inputs — for a compile, its whole staged source tree.
+		// Nix then bind-mounts that closure into every derivation that
+		// consumes the tree.
+		//
+		// Blanking them is safe because of ordering, not luck:
+		// cmdAssemble calls Walk on the ORIGINAL root and already holds
+		// every stub's drv path before StageForScan runs. The staged
+		// copy needs only the tree's SHAPE, and the assembly overlays
+		// the real artifact over each stub anyway.
+		//
+		// Keep an empty file rather than skipping: recipes stat their
+		// outputs, and the overlay's `cp -a` wants the path to exist.
+		return os.WriteFile(dst, nil, info.Mode().Perm())
 	default:
 		return copyFile(src, dst, info.Mode().Perm())
 	}

--- a/go/internal/assemble/assemble.go
+++ b/go/internal/assemble/assemble.go
@@ -31,9 +31,21 @@ type Stub struct {
 // build output. ".nix-socket" is builder-rpc-v0's own unix socket —
 // `nix store add --scan` can't ingest a socket. ".gg-stage" is
 // StageForScan's own working directory.
+//
+// ".nixgg" is nixgg's own scratch dir — staged source trees, thunks and
+// memo caches. It is scaffolding, never output, and capturing it is
+// expensive: `nix store add --scan` records a reference for every store
+// path it finds inside, which drags the whole staging closure into the
+// captured tree.
+//
+// Excluding it is safe. The final stage re-runs the build under the
+// shims and recreates what it needs; staged sources are already in the
+// store as derivation inputs; and sandbox mode marks outputs with
+// drvref stub FILES, so nothing in the tree points into .nixgg.
 var skipNames = map[string]bool{
 	".nix-socket": true,
 	".gg-stage":   true,
+	".nixgg":      true,
 }
 
 // Walk finds every drvref stub under root, in deterministic
@@ -143,6 +155,14 @@ func copyRecursive(src, dst string) error {
 			return err
 		}
 		for _, e := range entries {
+			// skipNames applies at EVERY depth, not just the root: the
+			// scratch dir sits at the project root paths.Resolve chose,
+			// which is usually several levels down. Walk already skips by
+			// name at any depth, so without this the two halves of the
+			// assembly disagree about what counts as build output.
+			if skipNames[e.Name()] {
+				continue
+			}
 			if err := copyRecursive(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
 				return err
 			}

--- a/go/internal/assemble/assemble_test.go
+++ b/go/internal/assemble/assemble_test.go
@@ -185,3 +185,44 @@ func TestStageForScanIsSelfExcluding(t *testing.T) {
 		t.Errorf("a.txt should be staged: %v", err)
 	}
 }
+
+// .nixgg is nixgg's own scratch dir. Capturing it into the assembled
+// tree is expensive at scale: under shared staging it holds one symlink
+// farm per translation unit, and `nix store add --scan` records a
+// reference to every file object they point at.
+//
+// Neither Walk nor StageForScan may look inside it.
+func TestNixggScratchDirIsExcluded(t *testing.T) {
+	root := t.TempDir()
+	// A staged farm at the depth it actually occurs: nixgg puts its
+	// scratch dir at the project root, which is usually several levels
+	// down — NOT the top level. A version of this test using the top
+	// level passes against code that only filters the outer ReadDir.
+	farm := filepath.Join(root, "src-1.0", "build", ".nixgg", "srcs", "tu0")
+	if err := os.MkdirAll(farm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/nix/store/aaa-hdr.h", filepath.Join(farm, "hdr.h")); err != nil {
+		t.Fatal(err)
+	}
+	// A thunk, and a stub that must NOT be mistaken for build output.
+	if err := os.WriteFile(filepath.Join(root, "src-1.0", "build", ".nixgg", "scan-cache"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Real output alongside it.
+	if err := os.WriteFile(filepath.Join(root, "src-1.0", "build", "real.txt"), []byte("out"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	staged, err := StageForScan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(staged, "src-1.0", "build", ".nixgg")); !os.IsNotExist(err) {
+		t.Error(".nixgg was copied into the staged tree; its closure would pull in " +
+			"every staged source object")
+	}
+	if _, err := os.Lstat(filepath.Join(staged, "src-1.0", "build", "real.txt")); err != nil {
+		t.Errorf("real build output was not staged: %v", err)
+	}
+}

--- a/go/internal/assemble/assemble_test.go
+++ b/go/internal/assemble/assemble_test.go
@@ -226,3 +226,60 @@ func TestNixggScratchDirIsExcluded(t *testing.T) {
 		t.Errorf("real build output was not staged: %v", err)
 	}
 }
+
+// A drvref stub's content is a /nix/store/….drv path, and
+// `nix store add --scan` records every store path it finds. Copying
+// stubs verbatim therefore makes the captured tree reference every
+// producing derivation — and a derivation's closure contains its own
+// inputs, so for a TU that is its staged source farm and every header in
+// it.
+//
+// At scale that is tens of thousands of stubs pulling in the whole
+// staging closure, which Nix bind-mounts into every derivation that
+// consumes the tree — enough to exceed the kernel mount limit and fail
+// as "No space left on device" on a disk that is nowhere near full.
+//
+// Walk runs before StageForScan and already holds every drv path, and
+// the assembly overlays the real artifact over each stub, so the staged
+// bytes are dead. Blank them.
+func TestStageForScanBlanksDrvrefStubs(t *testing.T) {
+	root := t.TempDir()
+	drvPath := "/nix/store/00000000000000000000000000000000-tu-x.o.drv"
+	stub := filepath.Join(root, "x.o")
+	if err := os.WriteFile(stub, []byte(drvref.Body(drvPath)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(root, "real.txt")
+	if err := os.WriteFile(real, []byte("genuine output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Walk must still see the stub: it runs first and is what the
+	// assembly is built from.
+	stubs, err := Walk(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stubs) != 1 || stubs[0].DrvPath != drvPath {
+		t.Fatalf("Walk lost the stub: %+v", stubs)
+	}
+
+	staged, err := StageForScan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(staged, "x.o"))
+	if err != nil {
+		t.Fatalf("staged stub missing entirely; the overlay needs the path to exist: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("staged stub still carries %d bytes (%q) — --scan will record "+
+			"a reference to the drv and drag in its whole input closure",
+			len(got), string(got))
+	}
+	// Real output must be untouched.
+	if b, err := os.ReadFile(filepath.Join(staged, "real.txt")); err != nil || string(b) != "genuine output" {
+		t.Errorf("real build output was altered: %q %v", string(b), err)
+	}
+}

--- a/go/internal/cli/assemble.go
+++ b/go/internal/cli/assemble.go
@@ -1,11 +1,20 @@
-// cmdAssemble implements `nixgg assemble <root> <name>`.
+// cmdAssemble implements `nixgg assemble <root> <name> [outputKey]`.
 //
 // splitStdenv's build-stage postBuild step: <root> is a tree of real
 // files interleaved with drvref stubs (one per cc/c++/ar/link call the
 // shims intercepted — see internal/drvref). Walk it, build one
 // assembly drv whose builder restores the tree and overlays each stub
-// with its resolved artifact, and submit it as the outer derivation's
-// "out" output.
+// with its resolved artifact, and submit it as one of the outer
+// derivation's outputs.
+//
+// outputKey defaults to "out", which is dynDrvStdenv's shape: its
+// phase-1 derivation declares exactly one output. mkNixggBuild is the
+// caller that needs it explicit — since the multi-target rework its
+// outer derivation declares "<target>.drv" per target and NO "out" at
+// all, so submitting under "out" fails with "submitted unknown output".
+// The name argument must agree: Nix enforces that the submitted drv is
+// named outputPathName(<outer name>, outputKey), i.e. the outer name
+// plus "-" plus outputKey minus its ".drv" suffix.
 package cli
 
 import (
@@ -19,10 +28,14 @@ import (
 )
 
 func cmdAssemble(args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("usage: nixgg assemble <root> <name>")
+	if len(args) != 2 && len(args) != 3 {
+		return fmt.Errorf("usage: nixgg assemble <root> <name> [output-key]")
 	}
 	root, name := args[0], args[1]
+	outputKey := "out"
+	if len(args) == 3 && args[2] != "" {
+		outputKey = args[2]
+	}
 
 	cfg, err := toolchain.FromEnv()
 	if err != nil {
@@ -65,9 +78,9 @@ func cmdAssemble(args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "[nixgg assemble] drv: %s\n", drvPath)
 
-	if err := sandbox.SubmitOutput(cfg, drvPath, "out"); err != nil {
+	if err := sandbox.SubmitOutput(cfg, drvPath, outputKey); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "[nixgg assemble] submitted: %s\n", drvPath)
+	fmt.Fprintf(os.Stderr, "[nixgg assemble] submitted: %s (output %s)\n", drvPath, outputKey)
 	return nil
 }

--- a/go/internal/dispatch/dispatch.go
+++ b/go/internal/dispatch/dispatch.go
@@ -180,6 +180,31 @@ func IsCompile(argv []string) bool {
 //
 // If no @-file is present the input is returned unchanged (no copy).
 func ExpandRspfiles(argv []string) []string {
+	return expandArgfiles(argv, splitRspLine)
+}
+
+// ExpandRustArgfiles is ExpandRspfiles for rustc, whose @-file format is
+// NOT the compiler-driver one: each LINE is exactly one argument, taken
+// verbatim, with no quote processing at all.
+//
+// The difference is not cosmetic. A kernel's generated cfg file holds
+// lines like
+//
+//	--cfg=CONFIG_RTC_DRV_CROS_EC="m"
+//
+// and rustc REQUIRES those quotes — `--cfg key="value"` is its grammar.
+// Tokenising the line the compiler-driver way strips them and rustc
+// rejects the result outright:
+//
+//	error: invalid `--cfg` argument: `CONFIG_RTC_DRV_CROS_EC=m`
+//
+// In the other direction a value containing spaces, legal on one line
+// here, would be split into several arguments.
+func ExpandRustArgfiles(argv []string) []string {
+	return expandArgfiles(argv, func(line string) []string { return []string{line} })
+}
+
+func expandArgfiles(argv []string, split func(string) []string) []string {
 	// Fast path: no @-arg → no allocation.
 	hasRsp := false
 	for _, a := range argv {
@@ -199,7 +224,7 @@ func ExpandRspfiles(argv []string) []string {
 	out := make([]string, 0, len(argv))
 	for _, a := range argv {
 		if len(a) > 1 && a[0] == '@' {
-			if body, err := readRspfile(a[1:]); err == nil {
+			if body, err := readArgfile(a[1:], split); err == nil {
 				out = append(out, body...)
 				continue
 			}
@@ -209,7 +234,7 @@ func ExpandRspfiles(argv []string) []string {
 	return out
 }
 
-func readRspfile(path string) ([]string, error) {
+func readArgfile(path string, split func(string) []string) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -219,7 +244,7 @@ func readRspfile(path string) ([]string, error) {
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
 	for sc.Scan() {
-		out = append(out, splitRspLine(sc.Text())...)
+		out = append(out, split(sc.Text())...)
 	}
 	if err := sc.Err(); err != nil {
 		return nil, err

--- a/go/internal/dispatch/dispatch.go
+++ b/go/internal/dispatch/dispatch.go
@@ -25,6 +25,10 @@ const (
 	ToolAR
 	ToolRanlib
 	ToolLD
+	// ToolObjtool: a tool that rewrites an object in place after
+	// compiling it. Reached only when the caller points the build's
+	// `objtool=` make variable at our shim.
+	ToolObjtool
 )
 
 // Basename returns the argv[0] name we advertise to the sandbox.
@@ -46,6 +50,8 @@ func (t Tool) Basename() string {
 		return "ranlib"
 	case ToolLD:
 		return "ld"
+	case ToolObjtool:
+		return "objtool"
 	}
 	return ""
 }
@@ -107,6 +113,8 @@ func FromArgv0(argv0 string) Tool {
 		return ToolRanlib
 	case "ld", "ld.bfd", "ld.gold", "ld.lld":
 		return ToolLD
+	case "objtool":
+		return ToolObjtool
 	}
 	return ToolUnknown
 }

--- a/go/internal/dispatch/dispatch.go
+++ b/go/internal/dispatch/dispatch.go
@@ -29,6 +29,11 @@ const (
 	// compiling it. Reached only when the caller points the build's
 	// `objtool=` make variable at our shim.
 	ToolObjtool
+	// ToolRustc: a rustc crate compile. Unlike the C compilers, one
+	// invocation consumes a whole crate — a source file plus every
+	// module, `include!` and macro file it reaches — and may emit
+	// several artifacts from it.
+	ToolRustc
 	// ToolObjcopy: a generic object rewrite
 	// (scripts/Makefile.lib cmd_objcopy), used for symbol prefixing
 	// and section stripping.
@@ -58,6 +63,8 @@ func (t Tool) Basename() string {
 		return "objtool"
 	case ToolObjcopy:
 		return "objcopy"
+	case ToolRustc:
+		return "rustc"
 	}
 	return ""
 }
@@ -123,6 +130,8 @@ func FromArgv0(argv0 string) Tool {
 		return ToolObjtool
 	case "objcopy":
 		return ToolObjcopy
+	case "rustc":
+		return ToolRustc
 	}
 	return ToolUnknown
 }

--- a/go/internal/dispatch/dispatch.go
+++ b/go/internal/dispatch/dispatch.go
@@ -29,6 +29,10 @@ const (
 	// compiling it. Reached only when the caller points the build's
 	// `objtool=` make variable at our shim.
 	ToolObjtool
+	// ToolObjcopy: a generic object rewrite
+	// (scripts/Makefile.lib cmd_objcopy), used for symbol prefixing
+	// and section stripping.
+	ToolObjcopy
 )
 
 // Basename returns the argv[0] name we advertise to the sandbox.
@@ -52,6 +56,8 @@ func (t Tool) Basename() string {
 		return "ld"
 	case ToolObjtool:
 		return "objtool"
+	case ToolObjcopy:
+		return "objcopy"
 	}
 	return ""
 }
@@ -115,6 +121,8 @@ func FromArgv0(argv0 string) Tool {
 		return ToolLD
 	case "objtool":
 		return ToolObjtool
+	case "objcopy":
+		return ToolObjcopy
 	}
 	return ToolUnknown
 }

--- a/go/internal/dispatch/dispatch_test.go
+++ b/go/internal/dispatch/dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -72,7 +73,8 @@ func TestFromArgv0(t *testing.T) {
 		{"ld", ToolLD},
 
 		// A whole-crate compiler rather than a per-TU one — see
-		// shim.Rustc. Reached through PATH, which no other shim is.
+		// shim.Rustc. Reached only when a caller points the build's
+		// RUSTC at our shim; nothing resolves it via PATH.
 		{"rustc", ToolRustc},
 		{"/nix/store/xxx-rustc-1.95.0/bin/rustc", ToolRustc},
 
@@ -228,5 +230,45 @@ func TestExpandRspfilesLeavesNonFilesAlone(t *testing.T) {
 	got := ExpandRspfiles(in)
 	if !reflect.DeepEqual(got, in) {
 		t.Errorf("ExpandRspfiles mangled a non-file @arg\n got: %q\nwant: %q", got, in)
+	}
+}
+
+// rustc's @-file format is not the compiler drivers': one line is one
+// argument, verbatim. The kernel's generated cfg file is the case that
+// matters, and it fails loudly rather than subtly — rustc requires the
+// quotes that shell tokenisation removes:
+//
+//	error: invalid `--cfg` argument: `CONFIG_RTC_DRV_CROS_EC=m`
+//
+// which is where this came from.
+func TestExpandRustArgfilesKeepsLinesVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rustc_cfg")
+	body := "--cfg=CONFIG_RTC_DRV_CROS_EC\n" +
+		"--cfg=CONFIG_RTC_DRV_CROS_EC=\"m\"\n" +
+		"--cfg=CONFIG_MSG=\"hello world\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ExpandRustArgfiles([]string{"--edition=2021", "@" + path, "lib.rs"})
+	want := []string{
+		"--edition=2021",
+		"--cfg=CONFIG_RTC_DRV_CROS_EC",
+		`--cfg=CONFIG_RTC_DRV_CROS_EC="m"`,
+		`--cfg=CONFIG_MSG="hello world"`,
+		"lib.rs",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExpandRustArgfiles =\n  %q\nwant\n  %q", got, want)
+	}
+
+	// The compiler-driver expander must still do its own thing — this is
+	// a second convention, not a replacement.
+	drv := ExpandRspfiles([]string{"@" + path})
+	for _, a := range drv {
+		if strings.Contains(a, `="m"`) {
+			t.Errorf("ExpandRspfiles now behaves like the rustc one: %q", drv)
+		}
 	}
 }

--- a/go/internal/dispatch/dispatch_test.go
+++ b/go/internal/dispatch/dispatch_test.go
@@ -71,6 +71,11 @@ func TestFromArgv0(t *testing.T) {
 		// passes straight through — see shim.LD.
 		{"ld", ToolLD},
 
+		// A whole-crate compiler rather than a per-TU one — see
+		// shim.Rustc. Reached through PATH, which no other shim is.
+		{"rustc", ToolRustc},
+		{"/nix/store/xxx-rustc-1.95.0/bin/rustc", ToolRustc},
+
 		// Not compilers.
 		{"make", ToolUnknown},
 		{"python3", ToolUnknown},

--- a/go/internal/dispatch/dispatch_test.go
+++ b/go/internal/dispatch/dispatch_test.go
@@ -66,6 +66,10 @@ func TestFromArgv0(t *testing.T) {
 		{"ld.gold", ToolLD},
 		{"ld.lld", ToolLD},
 		{"x86_64-linux-gnu-ld", ToolLD},
+		// Not a compiler, but modelled: `ld -r` partial links fuse
+		// multi-object components. Anything that is not `-r`
+		// passes straight through — see shim.LD.
+		{"ld", ToolLD},
 
 		// Not compilers.
 		{"make", ToolUnknown},

--- a/go/internal/expr/derivation.go
+++ b/go/internal/expr/derivation.go
@@ -30,6 +30,19 @@ const (
 	KindCompile Kind = iota // per-TU compile: builder.nix
 	KindLink                // linker step: linker.nix
 	KindArchive             // ar step: archiver.nix
+	// KindTransform: rewrite one existing object in place.
+	//
+	// Sandbox mode only — there is no native-mode helper for it, since
+	// the tools that need it (objtool, and `ld -r` for partial links)
+	// only appear in builds that already require the sandbox.
+	//
+	// Unlike the other three this produces no new artifact: it consumes
+	// one object and emits the same object, modified. Keeping it a
+	// separate derivation rather than folding it into the compile is
+	// deliberate — the compile stays cacheable independently of the
+	// transform's flags, so changing e.g. objtool's arguments rebuilds
+	// only this thin layer.
+	KindTransform
 )
 
 // Derivation is the intermediate representation both serializers
@@ -179,6 +192,14 @@ type Derivation struct {
 	// symbol-export list, not a large tree or hundreds of paths.
 	AbsFilePath    string
 	AbsFileContent string
+
+	// Transform-only: absolute /nix/store/… path of the binary that
+	// rewrites the object. Not taken from PATH like the compiler and
+	// `ar`, because this tool is built by the wrapped project itself
+	// (the build compiles it in its own prepare step) and reaches the
+	// store only because the shim adds it there — see
+	// shim.storeAddTool.
+	ToolBin string
 
 	// /nix/store/… roots referenced by Flags or WrapperEnv content;
 	// must be mounted in the sandbox. Serialized as _storeDeps env var
@@ -550,6 +571,22 @@ mkdir -p "%s"
 mkdir -p "%s"
 ar D%s "%s" %s
 `, pathPrefix, d.outDir(), d.ARFlags, d.outPath(), inputs())
+	case KindTransform:
+		// Copy first, then rewrite the copy: these tools edit in place
+		// and the input is a read-only store path. chmod because store
+		// paths arrive without write permission.
+		//
+		// PATH carries coreutils only — no compiler is involved, and the
+		// transform binary is invoked by absolute path.
+		return fmt.Sprintf(
+			`set -euo pipefail
+export PATH="%s/bin"
+mkdir -p "%s"
+cp %s "%s"
+chmod u+w "%s"
+"%s" %s "%s"
+`, coreutils, d.outDir(), inputs(), d.outPath(), d.outPath(),
+			d.ToolBin, shellQuoteFlags(d.Flags), d.outPath())
 	}
 	return ""
 }

--- a/go/internal/expr/derivation.go
+++ b/go/internal/expr/derivation.go
@@ -200,6 +200,12 @@ type Derivation struct {
 	AbsFilePath    string
 	AbsFileContent string
 
+	// Transform-only: does the tool rewrite its operand in place
+	// (objtool: one operand) or read one file and write another
+	// (objcopy: `objcopy <flags> <in> <out>`)? In-place needs the input
+	// copied out of its read-only store path first; in/out does not.
+	ToolInPlace bool
+
 	// Transform-only: absolute /nix/store/… path of the binary that
 	// rewrites the object. Not taken from PATH like the compiler and
 	// `ar`, because this tool is built by the wrapped project itself
@@ -590,12 +596,22 @@ mkdir -p "%s"
 "%s" %s -o "%s" %s
 `, coreutils, d.outDir(), d.ToolBin, shellQuoteFlags(d.Flags), d.outPath(), inputs())
 	case KindTransform:
-		// Copy first, then rewrite the copy: these tools edit in place
-		// and the input is a read-only store path. chmod because store
-		// paths arrive without write permission.
-		//
 		// PATH carries coreutils only — no compiler is involved, and the
 		// transform binary is invoked by absolute path.
+		if !d.ToolInPlace {
+			// `tool <flags> <in> <out>` — objcopy's shape. Nothing to
+			// copy: the tool reads the store path and writes $out.
+			return fmt.Sprintf(
+				`set -euo pipefail
+export PATH="%s/bin"
+mkdir -p "%s"
+"%s" %s %s "%s"
+`, coreutils, d.outDir(), d.ToolBin, shellQuoteFlags(d.Flags),
+				inputs(), d.outPath())
+		}
+		// In-place tools (objtool) rewrite their operand, so the input
+		// has to be copied out of its read-only store path first. chmod
+		// because store paths arrive without write permission.
 		return fmt.Sprintf(
 			`set -euo pipefail
 export PATH="%s/bin"

--- a/go/internal/expr/derivation.go
+++ b/go/internal/expr/derivation.go
@@ -50,6 +50,15 @@ const (
 	// `cmd_ld_multi_m` fuses a multi-object module's parts, and
 	// `cmd_ld_single` runs it over a single-object module on its own.
 	KindPartialLink
+	// KindRustc: one rustc crate compile.
+	//
+	// Sandbox mode only. Unlike KindCompile this is not one source in,
+	// one object out: a crate is a whole source TREE, and a single
+	// invocation can emit several artifacts from it (an object, the
+	// .rmeta its dependents resolve `--extern` against). They share a
+	// derivation because rustc produces them from one front-end run —
+	// splitting them would compile the crate twice.
+	KindRustc
 )
 
 // Derivation is the intermediate representation both serializers
@@ -214,6 +223,15 @@ type Derivation struct {
 	// shim.storeAddTool.
 	ToolBin string
 
+	// Rustc-only: the absolute /nix/store/… path of the real rustc.
+	// Not taken from PATH like the compiler, because a Rust build pins
+	// its toolchain and a crate compiled by a different rustc cannot be
+	// loaded by one that was not — rustc rejects mismatched metadata.
+	RustcBin string
+
+	// Rustc-only: the artifacts this invocation emits, in the caller's
+	// order. Each becomes an `--emit=<kind>=$out/<name>` argument.
+	Emits []RustEmit
 	// /nix/store/… roots referenced by Flags or WrapperEnv content;
 	// must be mounted in the sandbox. Serialized as _storeDeps env var
 	// (colon-joined) and threaded into inputs.srcs (JSON mode) /
@@ -223,6 +241,14 @@ type Derivation struct {
 	// Nix's gcc-wrapper env (NIX_CFLAGS_COMPILE, NIX_LDFLAGS, etc.).
 	// Preserved verbatim in the env dict.
 	WrapperEnv map[string]string
+}
+
+// RustEmit is one artifact a rustc invocation produces: the `--emit`
+// kind rustc knows it by ("obj", "metadata", "link"), and the filename
+// it lands under inside $out.
+type RustEmit struct {
+	Kind string
+	Name string
 }
 
 // derivInput is the internal per-input record used by Derivation's
@@ -243,6 +269,10 @@ type derivInput struct {
 	// producing derivation puts its artifact under one — see
 	// inputSubdirFor.
 	Name string
+	// Crate: KindRustc only. The name the consuming crate refers to
+	// this dependency by, which is not derivable from the filename —
+	// a crate's lib name and its `--crate-name` need not match.
+	Crate string
 }
 
 // inputSubdirFor returns the FHS subdirectory a sibling derivation's
@@ -294,6 +324,12 @@ func ArtifactSubdir(name string) string {
 		return ""
 	case strings.HasSuffix(base, ".a"):
 		return "lib"
+	case strings.HasSuffix(base, ".rmeta"), strings.HasSuffix(base, ".rlib"):
+		// Rust artifacts stay flat for the same reason .o does: a
+		// crate's metadata is an intermediate only the next rustc
+		// reads, not something buildEnv or `nix profile install` looks
+		// for.
+		return ""
 	}
 	return "bin"
 }
@@ -595,6 +631,85 @@ export PATH="%s/bin"
 mkdir -p "%s"
 "%s" %s -o "%s" %s
 `, coreutils, d.outDir(), d.ToolBin, shellQuoteFlags(d.Flags), d.outPath(), inputs())
+	case KindRustc:
+		// One front-end run, several artifacts. `--out-dir` is set even
+		// though every emit is named explicitly: rustc drops temporaries
+		// in the CURRENT directory otherwise, and the current directory
+		// here is the read-only staged source tree.
+		//
+		// Every input contributes a `-L dependency=` search path, and
+		// those named by the caller also get an explicit
+		// `--extern <crate>=<path>`. Both are needed, for different
+		// reasons.
+		//
+		// The explicit extern is what turns a filesystem search into a
+		// derivation input: the caller's bare `--extern <crate>` searches
+		// `-L` dirs that are the build tree, which the sandbox does not
+		// have and which hold drvref stubs outside it.
+		//
+		// The search paths are for the crates the caller never named. A
+		// crate's own dependencies travel in its metadata and rustc loads
+		// them from `-L` — a kernel driver names two externs and rustc
+		// then loads ten crates. Without a search path for each, the
+		// compile dies on a transitive dependency the command line never
+		// mentioned.
+		var parts []string
+		seenDir := map[string]bool{}
+		for _, in := range d.Inputs {
+			ref := in.Ref
+			name := in.Name
+			dir := ref
+			if in.InputKind == "store" {
+				if !strings.HasPrefix(ref, "/nix/store/") {
+					ref = "/nix/store/" + ref
+					dir = ref
+				}
+			} else {
+				ref = caOutputPlaceholder(in.Ref, "out")
+				dir = ref
+				// Only a sibling DRV places its artifact under an FHS
+				// subdir; a store input sits flat, the shape
+				// storeAddLooseFile produces. Applying the subdir to both
+				// would send the search path into a bin/ that does not
+				// exist.
+				if sub := inputSubdirFor(in.Name); sub != "" {
+					name = sub + "/" + name
+					dir = ref + "/" + sub
+				}
+			}
+			// Plain `-L`, not `-L dependency=`. The narrower kind only joins
+			// the search for a crate's own dependencies, and rustc looks for
+			// `core` — which a kernel compiles itself and passes here like
+			// any other crate — in the unrestricted path. Measured against
+			// the kernel's real artifacts, one directory per crate: with
+			// `dependency=` the compile dies on
+			//
+			//	error[E0463]: can't find crate for `core`
+			//
+			// and with plain `-L` it produces the object.
+			if !seenDir[dir] {
+				seenDir[dir] = true
+				parts = append(parts, fmt.Sprintf("-L '%s'", dir))
+			}
+			if in.Crate != "" {
+				parts = append(parts, fmt.Sprintf("--extern '%s=%s/%s'", in.Crate, ref, name))
+			}
+		}
+		for _, e := range d.Emits {
+			// Double quotes, not single: $out has to expand. Single
+			// quotes sent rustc a literal "$out/…" and it died trying to
+			// create a temp dir under a path with a dollar sign in it.
+			// Safe because both fields are a rustc emit kind and a
+			// basename this shim chose, never caller text.
+			parts = append(parts, fmt.Sprintf(`"--emit=%s=$out/%s"`, e.Kind, e.Name))
+		}
+		return fmt.Sprintf(
+			`set -euo pipefail
+export PATH="%s/bin"
+mkdir -p "$out"
+cd "$src"
+"%s" %s %s --out-dir "$out" "$source"
+`, coreutils, d.RustcBin, shellQuoteFlags(d.Flags), strings.Join(parts, " "))
 	case KindTransform:
 		// PATH carries coreutils only — no compiler is involved, and the
 		// transform binary is invoked by absolute path.
@@ -863,12 +978,17 @@ func (d *Derivation) envDict() map[string]string {
 	// (that's what builder.nix's script consults — see the
 	// `cd "$src"` / `"$source"` / `"$outName"` in script()). Link
 	// derivations reuse the same "src" slot for InlineFilesStore, when
-	// set — see inlineFilesScript's own docstring.
+	// set — see inlineFilesScript's own docstring. A rustc crate uses
+	// the same staged-tree slot as a compile, minus outName: its
+	// artifacts are named by the --emit flags, not by one output.
 	switch {
 	case d.Kind == KindCompile:
 		env["src"] = d.SrcStore
 		env["source"] = d.Source
 		env["outName"] = d.OutName
+	case d.Kind == KindRustc:
+		env["src"] = d.SrcStore
+		env["source"] = d.Source
 	case d.Kind == KindLink && d.InlineFilesStore != "":
 		env["src"] = d.InlineFilesStore
 	}

--- a/go/internal/expr/derivation.go
+++ b/go/internal/expr/derivation.go
@@ -43,6 +43,13 @@ const (
 	// transform's flags, so changing e.g. objtool's arguments rebuilds
 	// only this thin layer.
 	KindTransform
+	// KindPartialLink: `ld -r` — combine several objects into one
+	// object (not an executable, not an archive).
+	//
+	// Sandbox mode only, same as KindTransform. Reached when a build:
+	// `cmd_ld_multi_m` fuses a multi-object module's parts, and
+	// `cmd_ld_single` runs it over a single-object module on its own.
+	KindPartialLink
 )
 
 // Derivation is the intermediate representation both serializers
@@ -571,6 +578,17 @@ mkdir -p "%s"
 mkdir -p "%s"
 ar D%s "%s" %s
 `, pathPrefix, d.outDir(), d.ARFlags, d.outPath(), inputs())
+	case KindPartialLink:
+		// `-r` is supplied by the caller's own flag list, not added
+		// here: it is what identified this invocation as a partial link
+		// in the first place, so re-adding it would be a second source
+		// of truth.
+		return fmt.Sprintf(
+			`set -euo pipefail
+export PATH="%s/bin"
+mkdir -p "%s"
+"%s" %s -o "%s" %s
+`, coreutils, d.outDir(), d.ToolBin, shellQuoteFlags(d.Flags), d.outPath(), inputs())
 	case KindTransform:
 		// Copy first, then rewrite the copy: these tools edit in place
 		// and the input is a read-only store path. chmod because store

--- a/go/internal/expr/expr.go
+++ b/go/internal/expr/expr.go
@@ -407,6 +407,7 @@ type TransformJSONParams struct {
 	Bash        string
 	Coreutils   string
 	ToolBin     string // absolute /nix/store/… path of the rewriting binary
+	InPlace     bool   // true: tool rewrites its single operand (objtool)
 	Flags       []string
 	Input       JSONDrvInput
 	StoreDeps   []string
@@ -420,6 +421,7 @@ type TransformJSONParams struct {
 func TransformJSON(p TransformJSONParams) JSONDrv {
 	d := &Derivation{
 		Kind:       KindTransform,
+		ToolInPlace: p.InPlace,
 		Name:       p.Name,
 		System:     p.System,
 		Bash:       p.Bash,

--- a/go/internal/expr/expr.go
+++ b/go/internal/expr/expr.go
@@ -359,6 +359,9 @@ type JSONDrvInput struct {
 	Kind string
 	Ref  string
 	Name string
+	// Crate: rustc externs only. The name the consuming crate binds
+	// this dependency to.
+	Crate string
 }
 
 // ArchiveJSONParams is the sandbox-mode analog of ArchiveParams.
@@ -471,6 +474,47 @@ func PartialLinkJSON(p PartialLinkJSONParams) JSONDrv {
 	return d.toJSON(p.ExtraSrcs, nil)
 }
 
+// RustcJSONParams describes one rustc crate compile.
+type RustcJSONParams struct {
+	Name      string
+	System    string
+	Bash      string
+	Coreutils string
+	RustcBin  string // absolute /nix/store/…/bin/rustc
+	SrcStore  string // staged crate tree
+	// Source is relative to SrcStore, or an absolute /nix/store path
+	// when the crate root is itself already store content — Rust's own
+	// `core` is compiled straight out of the rustc source tree.
+	Source    string
+	Flags     []string
+	Externs   []JSONDrvInput // each carries the crate name it binds to
+	Emits     []RustEmit
+	StoreDeps []string
+	ExtraSrcs []string
+	Env       map[string]string
+}
+
+// RustcJSON produces a JSONDrv for a rustc crate compile. Sandbox mode
+// only: nothing that builds Rust reaches nixgg without it.
+func RustcJSON(p RustcJSONParams) JSONDrv {
+	d := &Derivation{
+		Kind:       KindRustc,
+		Name:       p.Name,
+		System:     p.System,
+		Bash:       p.Bash,
+		Coreutils:  p.Coreutils,
+		RustcBin:   p.RustcBin,
+		SrcStore:   p.SrcStore,
+		Source:     p.Source,
+		Flags:      p.Flags,
+		Inputs:     inputsFromJSON(p.Externs),
+		Emits:      p.Emits,
+		StoreDeps:  p.StoreDeps,
+		WrapperEnv: p.Env,
+	}
+	return d.toJSON(p.ExtraSrcs, nil)
+}
+
 // LinkJSON produces a JSONDrv for a link step. Delegates to
 // Derivation for env/script shape.
 func LinkJSON(p LinkJSONParams) JSONDrv {
@@ -516,7 +560,7 @@ func inputsFromJSON(xs []JSONDrvInput) []derivInput {
 		if kind == "store" && !strings.HasPrefix(ref, "/nix/store/") {
 			ref = "/nix/store/" + ref
 		}
-		out[i] = derivInput{InputKind: kind, Ref: ref, Name: in.Name}
+		out[i] = derivInput{InputKind: kind, Ref: ref, Name: in.Name, Crate: in.Crate}
 	}
 	return out
 }

--- a/go/internal/expr/expr.go
+++ b/go/internal/expr/expr.go
@@ -399,6 +399,41 @@ func ArchiveJSON(p ArchiveJSONParams) JSONDrv {
 	return d.toJSON(p.ExtraSrcs, nil)
 }
 
+// TransformJSONParams describes an in-place rewrite of one object.
+type TransformJSONParams struct {
+	Name        string
+	OutName     string
+	System      string
+	Bash        string
+	Coreutils   string
+	ToolBin     string // absolute /nix/store/… path of the rewriting binary
+	Flags       []string
+	Input       JSONDrvInput
+	StoreDeps   []string
+	Placeholder string
+	ExtraSrcs   []string
+	Env         map[string]string
+}
+
+// TransformJSON produces a JSONDrv for a KindTransform step: consume
+// one object, emit the same object rewritten. Sandbox mode only.
+func TransformJSON(p TransformJSONParams) JSONDrv {
+	d := &Derivation{
+		Kind:       KindTransform,
+		Name:       p.Name,
+		System:     p.System,
+		Bash:       p.Bash,
+		Coreutils:  p.Coreutils,
+		OutName:    p.OutName,
+		ToolBin:    p.ToolBin,
+		Flags:      p.Flags,
+		Inputs:     inputsFromJSON([]JSONDrvInput{p.Input}),
+		StoreDeps:  p.StoreDeps,
+		WrapperEnv: p.Env,
+	}
+	return d.toJSON(p.ExtraSrcs, nil)
+}
+
 // LinkJSON produces a JSONDrv for a link step. Delegates to
 // Derivation for env/script shape.
 func LinkJSON(p LinkJSONParams) JSONDrv {

--- a/go/internal/expr/expr.go
+++ b/go/internal/expr/expr.go
@@ -434,6 +434,41 @@ func TransformJSON(p TransformJSONParams) JSONDrv {
 	return d.toJSON(p.ExtraSrcs, nil)
 }
 
+// PartialLinkJSONParams describes an `ld -r` step.
+type PartialLinkJSONParams struct {
+	Name        string
+	OutName     string
+	System      string
+	Bash        string
+	Coreutils   string
+	ToolBin     string // absolute /nix/store/… path of `ld`
+	Flags       []string
+	Inputs      []JSONDrvInput
+	StoreDeps   []string
+	Placeholder string
+	ExtraSrcs   []string
+	Env         map[string]string
+}
+
+// PartialLinkJSON produces a JSONDrv for `ld -r`: several objects in,
+// one object out. Sandbox mode only.
+func PartialLinkJSON(p PartialLinkJSONParams) JSONDrv {
+	d := &Derivation{
+		Kind:       KindPartialLink,
+		Name:       p.Name,
+		System:     p.System,
+		Bash:       p.Bash,
+		Coreutils:  p.Coreutils,
+		OutName:    p.OutName,
+		ToolBin:    p.ToolBin,
+		Flags:      p.Flags,
+		Inputs:     inputsFromJSON(p.Inputs),
+		StoreDeps:  p.StoreDeps,
+		WrapperEnv: p.Env,
+	}
+	return d.toJSON(p.ExtraSrcs, nil)
+}
+
 // LinkJSON produces a JSONDrv for a link step. Delegates to
 // Derivation for env/script shape.
 func LinkJSON(p LinkJSONParams) JSONDrv {

--- a/go/internal/expr/expr.go
+++ b/go/internal/expr/expr.go
@@ -420,18 +420,18 @@ type TransformJSONParams struct {
 // one object, emit the same object rewritten. Sandbox mode only.
 func TransformJSON(p TransformJSONParams) JSONDrv {
 	d := &Derivation{
-		Kind:       KindTransform,
+		Kind:        KindTransform,
 		ToolInPlace: p.InPlace,
-		Name:       p.Name,
-		System:     p.System,
-		Bash:       p.Bash,
-		Coreutils:  p.Coreutils,
-		OutName:    p.OutName,
-		ToolBin:    p.ToolBin,
-		Flags:      p.Flags,
-		Inputs:     inputsFromJSON([]JSONDrvInput{p.Input}),
-		StoreDeps:  p.StoreDeps,
-		WrapperEnv: p.Env,
+		Name:        p.Name,
+		System:      p.System,
+		Bash:        p.Bash,
+		Coreutils:   p.Coreutils,
+		OutName:     p.OutName,
+		ToolBin:     p.ToolBin,
+		Flags:       p.Flags,
+		Inputs:      inputsFromJSON([]JSONDrvInput{p.Input}),
+		StoreDeps:   p.StoreDeps,
+		WrapperEnv:  p.Env,
 	}
 	return d.toJSON(p.ExtraSrcs, nil)
 }

--- a/go/internal/expr/script_golden_test.go
+++ b/go/internal/expr/script_golden_test.go
@@ -722,6 +722,11 @@ func TestOutSubdirAgreesWithInputSubdirFor(t *testing.T) {
 		// A shared library is a link output; bin/ is where the link drv
 		// puts whatever it was told to produce.
 		{KindLink, "libfoo.so"},
+		// A rustc crate's artifacts stay flat, like a compile's: both
+		// the object and the .rmeta its dependents resolve against are
+		// intermediates, not installables.
+		{KindRustc, "kernel.o"},
+		{KindRustc, "libkernel.rmeta"},
 	} {
 		producer := (&Derivation{Kind: tc.kind, OutName: tc.name}).outSubdir()
 		consumer := inputSubdirFor(tc.name)
@@ -806,5 +811,105 @@ func TestScriptCreatesTheDirectoryItWritesTo(t *testing.T) {
 				"fails with a missing-directory error, not a test failure:\n%s",
 				d.Kind, made, want, s)
 		}
+	}
+}
+
+// TestRustcScriptResolvesExternsAndEmits pins the two things the rustc
+// script does that no other Kind does.
+//
+// Externs: the caller's bare `--extern kernel` searches `-L` dirs, which
+// inside the sandbox do not exist. Every extern must come out as an
+// explicit `<crate>=<path>` binding pointing at the producing
+// derivation's output, or the crate compiles against nothing and the
+// dependency edge Nix enforces is a lie.
+//
+// Emits: one invocation, several artifacts. Dropping an emit yields a
+// derivation that builds cleanly and silently omits the .rmeta every
+// dependent crate resolves against — a failure that surfaces one crate
+// later, naming the wrong file.
+func TestRustcScriptResolvesExternsAndEmits(t *testing.T) {
+	d := &Derivation{
+		Kind:      KindRustc,
+		Name:      "rs-kernel.o",
+		System:    "x86_64-linux",
+		Bash:      "/nix/store/bbb-bash",
+		Coreutils: "/nix/store/ccc-coreutils",
+		RustcBin:  "/nix/store/rrr-rustc/bin/rustc",
+		SrcStore:  "/nix/store/sss-rs-kernel",
+		Source:    "rust/kernel/lib.rs",
+		Flags:     []string{"--crate-type", "rlib", "--edition=2021"},
+		Inputs: []derivInput{
+			{InputKind: "nix", Ref: "/nix/store/ddd-rs-ffi.o.drv", Name: "libffi.rmeta", Crate: "ffi"},
+			{InputKind: "store", Ref: "/nix/store/eee-prebuilt", Name: "libpin_init.rmeta", Crate: "pin_init"},
+		},
+		Emits: []RustEmit{
+			{Kind: "obj", Name: "kernel.o"},
+			{Kind: "metadata", Name: "libkernel.rmeta"},
+		},
+	}
+	script := d.script()
+
+	for _, want := range []string{
+		"--extern 'ffi=" + caOutputPlaceholder("/nix/store/ddd-rs-ffi.o.drv", "out") + "/libffi.rmeta'",
+		"--extern 'pin_init=/nix/store/eee-prebuilt/libpin_init.rmeta'",
+		`"--emit=obj=$out/kernel.o"`,
+		`"--emit=metadata=$out/libkernel.rmeta"`,
+		`--out-dir "$out"`,
+		`cd "$src"`,
+		`"$source"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("rustc script missing %q\n--- script ---\n%s", want, script)
+		}
+	}
+	// A bare extern reaching the sandbox means -L resolution was relied
+	// on, which cannot work there.
+	if strings.Contains(script, "--extern 'ffi'") || strings.Contains(script, "--extern ffi ") {
+		t.Errorf("rustc script emitted an unresolved extern\n%s", script)
+	}
+}
+
+// A crate's own dependencies travel in its metadata, not on the command
+// line: a kernel driver names two externs and rustc then loads ten
+// crates, resolving the rest from `-L`. Every input therefore needs a
+// search path, or the compile dies on a transitive dependency nothing
+// on the command line ever mentioned.
+func TestRustcScriptEmitsSearchPathPerInput(t *testing.T) {
+	d := &Derivation{
+		Kind: KindRustc, Name: "rs-drm_panic_qr.o", System: "x86_64-linux",
+		Bash: "/nix/store/bbb-bash", Coreutils: "/nix/store/ccc-coreutils",
+		RustcBin: "/nix/store/rrr-rustc/bin/rustc",
+		SrcStore: "/nix/store/sss-crate", Source: "drm_panic_qr.rs",
+		Inputs: []derivInput{
+			// Named on the command line.
+			{InputKind: "nix", Ref: "/nix/store/ddd-rs-kernel.o.drv", Name: "libkernel.rmeta", Crate: "kernel"},
+			// Never named: reached only through the search path.
+			{InputKind: "nix", Ref: "/nix/store/eee-rs-uapi.o.drv", Name: "libuapi.rmeta"},
+			{InputKind: "store", Ref: "/nix/store/fff-macros", Name: "libmacros.so"},
+		},
+		Emits: []RustEmit{{Kind: "obj", Name: "drm_panic_qr.o"}},
+	}
+	script := d.script()
+
+	for _, want := range []string{
+		"-L '" + caOutputPlaceholder("/nix/store/ddd-rs-kernel.o.drv", "out") + "'",
+		"-L '" + caOutputPlaceholder("/nix/store/eee-rs-uapi.o.drv", "out") + "'",
+		"--extern 'kernel=" + caOutputPlaceholder("/nix/store/ddd-rs-kernel.o.drv", "out") + "/libkernel.rmeta'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("rustc script missing %q\n--- script ---\n%s", want, script)
+		}
+	}
+	// An unnamed input must NOT get an --extern: rustc rejects a crate
+	// bound to a name the source never refers to.
+	if strings.Contains(script, "--extern '=") {
+		t.Errorf("search-path-only input got an empty --extern binding\n%s", script)
+	}
+	// A store input sits FLAT — the shape storeAddLooseFile produces for
+	// a proc-macro left as a real file. Only a sibling drv places its
+	// artifact under an FHS subdir, so applying it to both would send
+	// the search path into a bin/ that does not exist.
+	if !strings.Contains(script, "-L '/nix/store/fff-macros'") {
+		t.Errorf("search path for a store input must not gain an FHS subdir\n%s", script)
 	}
 }

--- a/go/internal/mode/mode.go
+++ b/go/internal/mode/mode.go
@@ -26,11 +26,26 @@ type Mode int
 const (
 	Placeholder Mode = iota
 	Realise
+	// Passthrough: run the real compiler in the build tree and model
+	// nothing.
+	//
+	// A different reason from Realise. Realise is for builds that need a
+	// runnable artifact immediately; Passthrough is for compiles the
+	// build EXPECTS TO FAIL, where the failure is the result and the
+	// artifact is the compiler's stderr.
+	//
+	// Accelerating those is not merely wasteful, it is wrong: a
+	// derivation that fails, fails the build, whereas the caller was
+	// going to inspect the error and carry on. Realise is no help
+	// either — `nix build` on a deliberately-failing compile fails just
+	// as hard.
+	Passthrough
 )
 
 // For returns the mode for a given source or output path.
 //
-// Placeholder unless the path matches a known conftest/probe pattern:
+// Placeholder unless the path matches:
+//   - a caller-declared passthrough subtree (passthrough.go)
 //   - autoconf conftests (basename starts with "conftest")
 //   - cmake compiler-detection files (test?Compiler…, CheckXXX…)
 //   - cmake TryCompile scratch (path contains CMakeFiles/CMake{Scratch,Tmp})
@@ -103,6 +118,9 @@ const (
 func For(path string) Mode {
 	base := filepath.Base(path)
 	switch {
+	// Project-specific subtrees the caller declared — see passthrough.go.
+	case matchesPassthrough(path):
+		return Passthrough
 	case strings.HasPrefix(base, "conftest"):
 		return Realise
 	case matchCMakeProbe(base):

--- a/go/internal/mode/passthrough.go
+++ b/go/internal/mode/passthrough.go
@@ -1,0 +1,89 @@
+package mode
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Project-specific passthrough paths, supplied by the caller rather than
+// compiled in.
+//
+// The rule mode.For encodes is general: some subtrees build by reading
+// object BYTES inline — `nm $(real-prereqs) | sed > $@`, an objdump
+// piped to grep that decides whether to fail — and a derivation cannot
+// model that, because the answer is needed before make continues.
+//
+// WHICH subtrees do it is not general at all: they are specific to a
+// project, often to its target architecture and version. Compiling a
+// list into a general-purpose tool makes every such change a Go change,
+// and every other project carries dead string comparisons.
+//
+// So the paths come from $NIXGG_PASSTHROUGH_PATHS, a JSON array the
+// caller sets — the same shape and the same eval-time-computed contract
+// as $NIXGG_KNOWN_STORE_PATHS, which matters because both modes must
+// export it identically or native and sandbox drv hashes diverge.
+//
+// Matching stays substring-based, as the compiled-in version was: these
+// name a subtree, and both a source and the object built from it have
+// to match, from any working
+// directory make happens to be in.
+//
+// What deliberately does NOT move here: rules keyed on build-system
+// CONVENTION rather than project layout — autoconf's conftest, cmake's
+// probe files and scratch dirs. Those are properties of the tool that
+// generated the build, identical across every project using it, so they
+// stay compiled in.
+
+const passthroughEnv = "NIXGG_PASSTHROUGH_PATHS"
+
+var (
+	ptOnce  sync.Once
+	ptPaths []string
+)
+
+// passthroughPaths returns the configured subtrees, parsed once.
+//
+// Unset or unparseable yields none rather than an error: a project with
+// no such subtrees is the normal case, and every example build has none.
+func passthroughPaths() []string {
+	ptOnce.Do(func() { ptPaths = parsePassthrough(os.Getenv(passthroughEnv)) })
+	return ptPaths
+}
+
+func parsePassthrough(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil
+	}
+	// Drop empties: a stray "" would substring-match every path and
+	// silently pass the entire build through, which looks like nixgg
+	// accelerating nothing rather than like a config error.
+	kept := out[:0]
+	for _, p := range out {
+		if strings.TrimSpace(p) != "" {
+			kept = append(kept, p)
+		}
+	}
+	return kept
+}
+
+// SetPassthroughPaths overrides the configured paths. For tests only —
+// production reads the environment exactly once.
+func SetPassthroughPaths(paths []string) {
+	ptOnce.Do(func() {}) // consume the once so the env cannot overwrite
+	ptPaths = paths
+}
+
+func matchesPassthrough(path string) bool {
+	for _, p := range passthroughPaths() {
+		if strings.Contains(path, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/mode/passthrough_test.go
+++ b/go/internal/mode/passthrough_test.go
@@ -1,0 +1,84 @@
+package mode
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePassthrough(t *testing.T) {
+	for _, tc := range []struct {
+		name, in string
+		want     []string
+	}{
+		{"two subtrees", `["src/embed/","tools/gen/"]`,
+			[]string{"src/embed/", "tools/gen/"}},
+		{"empty array", `[]`, nil},
+		{"unset", "", nil},
+		{"whitespace", "   ", nil},
+		// Unparseable must not be fatal: a malformed value should cost
+		// acceleration in one subtree, not fail every compile in the
+		// build with a JSON error from inside a shim.
+		{"malformed json", `["unterminated`, nil},
+		{"not an array", `"src/embed/"`, nil},
+		// THE dangerous case. An empty string substring-matches every
+		// path, so a stray "" would pass the ENTIRE build through — and
+		// that looks like nixgg silently accelerating nothing rather
+		// than like a configuration error, which is far worse than a
+		// hard failure.
+		{"empty element is dropped", `["", "tools/gen/"]`, []string{"tools/gen/"}},
+		{"all empty elements", `["", "  "]`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePassthrough(tc.in)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parsePassthrough(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// A project that configures nothing must get no carveouts — that is
+// every example build, and it is what keeps this change invisible to
+// them.
+func TestNoConfiguredPathsMeansNoCarveouts(t *testing.T) {
+	SetPassthroughPaths(nil)
+	defer SetPassthroughPaths([]string{
+		"src/embed/", "tools/gen/",
+	})
+
+	for _, p := range []string{
+		"src/embed/blob.S",
+		"tools/gen/empty.c",
+		"src/main.c",
+	} {
+		if got := For(p); got != Placeholder {
+			t.Errorf("For(%q) = %v with no configuration, want Placeholder", p, got)
+		}
+	}
+}
+
+// Build-system conventions stay compiled in: they are properties of
+// autoconf and cmake, identical in every project that uses them, so a
+// caller must not have to declare them.
+func TestConventionRulesSurviveWithoutConfiguration(t *testing.T) {
+	SetPassthroughPaths(nil)
+	defer SetPassthroughPaths([]string{"tools/gen/"})
+
+	for _, tc := range []struct {
+		path string
+		want Mode
+	}{
+		{"conftest.c", Realise},
+		{"/tmp/build/conftest.cpp", Realise},
+		{"testCCompiler.c", Realise},
+		{"/x/CMakeFiles/CMakeScratch/TryCompile-ab12/src.cxx", Realise},
+	} {
+		if got := For(tc.path); got != tc.want {
+			t.Errorf("For(%q) = %v, want %v — convention rules must not "+
+				"depend on caller configuration", tc.path, got, tc.want)
+		}
+	}
+}

--- a/go/internal/mode/passthrough_test.go
+++ b/go/internal/mode/passthrough_test.go
@@ -82,3 +82,22 @@ func TestConventionRulesSurviveWithoutConfiguration(t *testing.T) {
 		}
 	}
 }
+
+// A declared subtree is about where the OBJECT lands, not where its
+// source lives: a build may compile a source from elsewhere into it.
+// Keying on the source alone lets those objects through as stubs, and
+// whatever the subtree does with their bytes then fails.
+func TestPassthroughKeysOnOutputNotJustSource(t *testing.T) {
+	SetPassthroughPaths([]string{"src/embed/"})
+	defer SetPassthroughPaths([]string{"tools/gen/"})
+
+	// An ordinary source outside the subtree: accelerate it.
+	if got := For("../lib/cmdline.c"); got != Placeholder {
+		t.Errorf("For(lib/cmdline.c) = %v, want Placeholder", got)
+	}
+	// The object landing inside it must not be modelled. The compile
+	// shim checks both, so this is the half that matters.
+	if got := For("src/embed/lib-cmdline.o"); got != Passthrough {
+		t.Errorf("For(src/embed/lib-cmdline.o) = %v, want Passthrough", got)
+	}
+}

--- a/go/internal/sandbox/sandbox.go
+++ b/go/internal/sandbox/sandbox.go
@@ -142,6 +142,11 @@ func DerivationAdd(cfg *toolchain.Config, drv expr.JSONDrv) (string, error) {
 // highest-volume of the three sandbox ops (one call per compile TU,
 // same as DerivationAdd).
 func StoreAddScan(cfg *toolchain.Config, name, path string) (string, error) {
+	// Sanitized once, before a backend is chosen: every path below —
+	// helper, direct RPC, and the CLI fallback — hands this name to the
+	// daemon, and Nix's naming rules apply identically to each. Doing it
+	// per-backend would let a new one be added without it.
+	name = StoreName(name)
 	if b, closeB, ok, err := selectBackend(); err != nil {
 		return "", fmt.Errorf("rpc store add --scan: %w", err)
 	} else if ok {

--- a/go/internal/sandbox/storename.go
+++ b/go/internal/sandbox/storename.go
@@ -1,0 +1,45 @@
+package sandbox
+
+import "strings"
+
+// StoreName makes a store-object name out of a filename.
+//
+// Nix restricts store path names to [A-Za-z0-9+._?=-] and rejects
+// anything else outright. Naming a store object after the file it holds
+// puts arbitrary source filenames through that check, and real projects
+// have filenames Nix will not accept.
+//
+// Renaming is safe: the name is cosmetic here, since a staged tree
+// references the object by its own path and identity comes from the
+// content hash. Two filenames can map to the same name, which only
+// matters if their content is identical too — in which case sharing one
+// object is correct.
+func StoreName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '+', r == '-', r == '.', r == '_', r == '?', r == '=':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	s := b.String()
+	// Nix caps names at 211 chars. Trim from the FRONT so the extension
+	// survives — it is the part that carries meaning when reading a log.
+	const max = 200
+	if len(s) > max {
+		s = s[len(s)-max:]
+	}
+	// A leading dot is rejected, and "." / ".." are not names at all.
+	// Trim AFTER the length clamp: truncating can expose a dot that was
+	// interior in the full string, which would put a name Nix rejects
+	// back on the wire.
+	s = strings.TrimLeft(s, ".")
+	if s == "" {
+		s = "unnamed"
+	}
+	return s
+}

--- a/go/internal/sandbox/storename_test.go
+++ b/go/internal/sandbox/storename_test.go
@@ -1,0 +1,62 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+// Nix rejects a store name containing ',', and real source trees have
+// filenames that use it.
+func TestStoreName(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"util.h", "util.h"},
+		{"vendor,device.h", "vendor_device.h"},
+		{"main.c", "main.c"},
+		// Every character Nix actually permits must survive untouched,
+		// or we would rename files needlessly and lose sharing.
+		{"a+b-c.d_e?f=g.h", "a+b-c.d_e?f=g.h"},
+		// A leading dot is rejected by Nix.
+		{".config", "config"},
+		{"..", "unnamed"},
+		{"", "unnamed"},
+		// Non-ASCII and shell metacharacters.
+		// Non-ASCII: range yields runes, so one multi-byte char -> one "_".
+		{"naïve.h", "na_ve.h"},
+		{"a b;c.h", "a_b_c.h"},
+	} {
+		if got := StoreName(tc.in); got != tc.want {
+			t.Errorf("StoreName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Whatever comes out must satisfy Nix's rules, or the rename accomplished
+// nothing. Checked as a property so a future edit to the allowed set
+// cannot quietly reintroduce an illegal character.
+func TestStoreNameAlwaysValid(t *testing.T) {
+	const legal = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+-._?="
+	for _, in := range []string{
+		"vendor,device.h", "", ".", "..", ".hidden", "a/b.h", "x\x00y.h",
+		strings.Repeat("long", 200) + ".h", "日本語.h", "a b;c|d&e.h",
+		// Over-length, with a dot landing exactly on the truncation
+		// boundary: the name has no leading dot, but the last 200 chars
+		// start with one. Trimming before the clamp would let it through.
+		"a." + strings.Repeat("x", 199),
+	} {
+		got := StoreName(in)
+		if got == "" {
+			t.Errorf("StoreName(%q) produced an empty name", in)
+		}
+		if strings.HasPrefix(got, ".") {
+			t.Errorf("StoreName(%q) = %q starts with a dot", in, got)
+		}
+		if len(got) > 211 {
+			t.Errorf("StoreName(%q) is %d chars, over Nix's 211 limit", in, len(got))
+		}
+		for _, r := range got {
+			if !strings.ContainsRune(legal, r) {
+				t.Errorf("StoreName(%q) = %q contains illegal %q", in, got, r)
+			}
+		}
+	}
+}

--- a/go/internal/scan/rust.go
+++ b/go/internal/scan/rust.go
@@ -1,0 +1,168 @@
+package scan
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tbereknyei/nixgg/internal/paths"
+)
+
+// RunRust enumerates the source set for one rustc crate compile.
+//
+//   - rustc:  absolute path to the real compiler
+//   - source: the crate root the caller named (its `$<`)
+//   - flags:  everything else on argv, minus -o and the --emit family
+//
+// The C scanner asks the preprocessor which headers a translation unit
+// reads. Rust has no preprocessor, so the equivalent question can only
+// be answered by the compiler front end — which rustc will answer
+// directly via `--emit=dep-info`, listing every file the crate reaches:
+// `mod` files, `include!`, `include_str!` and `include_bytes!`. That
+// last group matters because it is precisely the case `gcc -M` cannot
+// see (the `.incbin` problem the compile shim has to passthrough for);
+// here it comes for free.
+//
+// The exit status is deliberately ignored. Under nixgg a crate's
+// `--extern` dependencies are drvref stubs rather than real rlibs, so
+// rustc reports "extern location … is of an unknown type" and exits
+// non-zero. It writes the dep-info file anyway: dependency collection
+// happens during expansion, before and independently of crate
+// resolution. Verified across a missing extern, a stub extern and no
+// extern at all — all three produce the same complete dep list as a
+// build with the real rlib present.
+//
+// The one gap that leaves: a file pulled in by an `include!` that a
+// PROC-MACRO generated is invisible, because an unresolvable
+// proc-macro crate never expands. That is why shim.Rustc refuses to
+// model proc-macro crates — keeping their output a real file on disk
+// keeps every dependent crate's scan honest.
+func RunRust(l paths.Layout, rustc, source string, flags []string) (*Result, error) {
+	if err := os.MkdirAll(l.Scans, 0o755); err != nil {
+		return nil, err
+	}
+	key := cacheKey(rustc, source, flags)
+	if r, ok := readCache(l, key); ok {
+		return r, nil
+	}
+	r, deps, err := runRustScanner(rustc, source, flags)
+	if err != nil {
+		return nil, err
+	}
+	writeCache(l, key, r, deps)
+	return r, nil
+}
+
+func runRustScanner(rustc, source string, flags []string) (*Result, []depEntry, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+	srcAbs, err := filepath.Abs(source)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// rustc writes the crate's real artifacts unless told otherwise, and
+	// the caller's --out-dir points into the build tree. Redirect both
+	// the dep file and the artifacts into a scratch dir so a scan never
+	// touches what the build is about to produce.
+	tmp, err := os.MkdirTemp("", "nixgg-rustscan")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer os.RemoveAll(tmp)
+	depFile := filepath.Join(tmp, "dep-info")
+
+	args := append(stripRustEmitFlags(flags),
+		"--emit=dep-info="+depFile, "--out-dir", tmp, source)
+	cmd := exec.Command(rustc, args...)
+	// Kept, not discarded: when the dep file is missing this stderr is
+	// the only account of why, and without it the shim can say no more
+	// than "scan failed" about a crate that then silently builds
+	// unaccelerated.
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	_ = cmd.Run() // see the docstring: the dep file is written regardless
+
+	out, err := os.ReadFile(depFile)
+	if err != nil {
+		// No dep file at all means the front end never got far enough to
+		// expand the crate — the source set is unknown, not empty, and
+		// staging an empty tree would produce a drv that fails inside the
+		// sandbox with an error pointing at the wrong thing.
+		return nil, nil, fmt.Errorf("rustc wrote no dep-info for %s: %w\n%s",
+			source, err, tail(stderr.String(), 2000))
+	}
+
+	projectRoot := commonAncestor([]string{cwd, filepath.Dir(srcAbs)})
+	var resolved []string
+	for _, tok := range parseMakeDeps(out) {
+		abs, ok := resolveDep(tok, []string{cwd, filepath.Dir(srcAbs)})
+		if !ok || abs == srcAbs {
+			continue
+		}
+		if strings.HasPrefix(abs, "/nix/store/") {
+			// Already content-addressed; referenced by absolute path and
+			// mounted via storeDeps rather than copied into the tree.
+			continue
+		}
+		resolved = append(resolved, abs)
+	}
+	for _, abs := range resolved {
+		projectRoot = widen(projectRoot, filepath.Dir(abs))
+	}
+
+	seen := map[string]bool{}
+	var headers []Header
+	deps := []depEntry{statOr(srcAbs)}
+	for _, abs := range resolved {
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		rel, err := filepath.Rel(projectRoot, abs)
+		if err != nil {
+			return nil, nil, err
+		}
+		headers = append(headers, Header{Abs: abs, Rel: rel})
+		deps = append(deps, statOr(abs))
+	}
+	sort.Slice(headers, func(i, j int) bool { return headers[i].Rel < headers[j].Rel })
+
+	return &Result{Headers: headers, ProjectRoot: projectRoot}, deps, nil
+}
+
+// stripRustEmitFlags drops the caller's output-selection flags. We
+// supply our own --emit and --out-dir; leaving the caller's in place
+// would make the scan write the artifact the build is waiting for, from
+// a compile whose externs are stubs.
+//
+// -o is dropped for the same reason. Both attached (--emit=x) and
+// separated (--emit x) spellings occur.
+func stripRustEmitFlags(flags []string) []string {
+	out := make([]string, 0, len(flags))
+	for i := 0; i < len(flags); i++ {
+		f := flags[i]
+		switch {
+		case f == "--emit" || f == "--out-dir" || f == "-o":
+			i++ // also skip its value
+		case strings.HasPrefix(f, "--emit=") || strings.HasPrefix(f, "--out-dir="):
+		default:
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// tail returns the last n bytes of s, so a compiler's diagnostic reaches
+// the log without a thousand lines of lint output burying it.
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…" + s[len(s)-n:]
+}

--- a/go/internal/scan/rust_test.go
+++ b/go/internal/scan/rust_test.go
@@ -1,0 +1,120 @@
+package scan
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/tbereknyei/nixgg/internal/paths"
+)
+
+// The property RunRust depends on, and which nothing else in the suite
+// would catch if a future rustc changed it: rustc writes the dep-info
+// file even when the crate FAILS to compile. Under nixgg a crate's
+// `--extern` dependencies are drvref stubs, so every scan is such a
+// failing compile — if rustc ever started skipping dep-info on error,
+// the shim would stage an incomplete source tree and the resulting
+// derivation would fail deep inside the sandbox, naming a missing
+// module rather than the scan.
+//
+// Also pins that `include!` is reported. That is the reason this scanner
+// is worth having at all: it closes, for Rust, the hole `gcc -M` leaves
+// for `.incbin` — a file the compiler reads at expansion time, named in
+// a string no preprocessor examines.
+func TestRunRustFindsIncludesDespiteBrokenExtern(t *testing.T) {
+	rustc := requireRustc(t)
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "sub", "inc.rs"), "pub const X: u32 = 1;\n")
+	mustWrite(t, filepath.Join(root, "main.rs"),
+		"mod sub { include!(\"sub/inc.rs\"); }\n"+
+			"pub fn go() -> u32 { missingcrate::hi() + sub::X }\n")
+
+	chdir(t, root)
+	l := paths.Layout{Scans: filepath.Join(root, "scans")}
+	// A bare --extern with nothing to resolve it: the same shape a
+	// nixgg-shimmed build presents, minus the stub file.
+	r, err := RunRust(l, rustc, "main.rs",
+		[]string{"--crate-type=rlib", "--crate-name=app", "--edition=2021",
+			"--extern", "missingcrate"})
+	if err != nil {
+		t.Fatalf("RunRust: %v", err)
+	}
+	if !hasRel(r.Headers, "sub/inc.rs") {
+		t.Errorf("include!(\"sub/inc.rs\") missing from scan; got %v", rels(r.Headers))
+	}
+}
+
+// The scan must not write the artifact the build is waiting for. The
+// caller's --emit and --out-dir name real build outputs, and the scan
+// compiles with stub externs — so leaving them in place would drop a
+// broken object exactly where a correct one belongs.
+func TestRunRustLeavesCallerOutputsAlone(t *testing.T) {
+	rustc := requireRustc(t)
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "lib.rs"), "pub fn hi() -> u32 { 7 }\n")
+	chdir(t, root)
+
+	l := paths.Layout{Scans: filepath.Join(root, "scans")}
+	out := filepath.Join(root, "lib.o")
+	if _, err := RunRust(l, rustc, "lib.rs",
+		[]string{"--crate-type=rlib", "--crate-name=lib", "--edition=2021",
+			"--emit=obj=" + out, "--out-dir", root}); err != nil {
+		t.Fatalf("RunRust: %v", err)
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Errorf("scan wrote %s; the build's own compile must be the only thing that does", out)
+	}
+}
+
+func hasRel(hs []Header, rel string) bool {
+	for _, h := range hs {
+		if h.Rel == rel {
+			return true
+		}
+	}
+	return false
+}
+
+func rels(hs []Header) []string {
+	var out []string
+	for _, h := range hs {
+		out = append(out, h.Rel)
+	}
+	return out
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(old) })
+}
+
+// requireRustc skips when no rustc is available, so `go test ./...`
+// still passes on a machine without one.
+func requireRustc(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("rustc")
+	if err != nil {
+		t.Skip("no rustc on PATH; skipping rust scanner test")
+	}
+	return p
+}

--- a/go/internal/scan/scan.go
+++ b/go/internal/scan/scan.go
@@ -67,38 +67,52 @@ type Result struct {
 //   - source: caller's source file (relative to cwd is fine)
 //   - flags: everything else on argv (no -c/-o).
 //
-// Uses the cache under l.Scans if all deps' mtimes match.
+// Uses the cache under l.Scans if all deps mtimes match.
 func Run(l paths.Layout, cc, source string, flags []string) (*Result, error) {
 	if err := os.MkdirAll(l.Scans, 0o755); err != nil {
 		return nil, err
 	}
 	key := cacheKey(cc, source, flags)
-	depsPath := filepath.Join(l.Scans, key+".deps")
-	outPath := filepath.Join(l.Scans, key+".out")
-
-	if fresh, err := depsStillFresh(depsPath); err == nil && fresh {
-		if body, err := os.ReadFile(outPath); err == nil {
-			var r Result
-			if err := decodeResult(body, &r); err == nil {
-				return &r, nil
-			}
-		}
+	if r, ok := readCache(l, key); ok {
+		return r, nil
 	}
-
-	// Cache miss — do the real work.
 	r, deps, err := runScanner(cc, source, flags)
 	if err != nil {
 		return nil, err
 	}
+	writeCache(l, key, r, deps)
+	return r, nil
+}
+
+// readCache returns the memoised Result for key when every file it was
+// derived from still has the mtime the scan saw.
+func readCache(l paths.Layout, key string) (*Result, bool) {
+	if fresh, err := depsStillFresh(filepath.Join(l.Scans, key+".deps")); err != nil || !fresh {
+		return nil, false
+	}
+	body, err := os.ReadFile(filepath.Join(l.Scans, key+".out"))
+	if err != nil {
+		return nil, false
+	}
+	var r Result
+	if err := decodeResult(body, &r); err != nil {
+		return nil, false
+	}
+	return &r, true
+}
+
+// writeCache is best-effort: a scan that cannot be memoised still
+// returns its result, it just costs the same again next time. The deps
+// file is written only after the result, so a half-written cache is
+// never treated as fresh.
+func writeCache(l paths.Layout, key string, r *Result, deps []depEntry) {
 	body, err := encodeResult(r)
 	if err != nil {
-		return nil, err
+		return
 	}
-	// Write cache best-effort. If it fails we still return the result.
-	if err := writeAtomic(outPath, body); err == nil {
-		_ = writeAtomic(depsPath, encodeDeps(deps))
+	if err := writeAtomic(filepath.Join(l.Scans, key+".out"), body); err == nil {
+		_ = writeAtomic(filepath.Join(l.Scans, key+".deps"), encodeDeps(deps))
 	}
-	return r, nil
 }
 
 // depEntry is one line in the .deps file: <abs>\t<mtime-nsec>.

--- a/go/internal/scan/scan.go
+++ b/go/internal/scan/scan.go
@@ -461,20 +461,64 @@ func extractForceIncludes(flags []string) []string {
 	return out
 }
 
-func stripDepFlags(flags []string) []string {
-	var out []string
-	oneArg := map[string]bool{"-M": true, "-MM": true, "-MG": true, "-MP": true, "-MD": true, "-MMD": true}
-	twoArg := map[string]bool{"-MF": true, "-MT": true, "-MQ": true}
-	for i := 0; i < len(flags); i++ {
-		f := flags[i]
-		if oneArg[f] {
+var depOneArg = map[string]bool{"-M": true, "-MM": true, "-MG": true, "-MP": true, "-MD": true, "-MMD": true}
+var depTwoArg = map[string]bool{"-MF": true, "-MT": true, "-MQ": true}
+
+// StripWpDep removes dependency-generation directives from a `-Wp,…`
+// preprocessor-passthrough flag, returning the remainder and whether
+// anything survived.
+//
+// A `-Wp,-MMD,<file>` redirects dependency output to that file, which
+// silences the scanner's own `-M -MG -MF -`. It is equally invalid
+// inside the derivation, for the reason parseCompileArgs documents for
+// the bare -MD/-MMD forms.
+//
+// Shared with the compile shim so the two cannot disagree about which
+// flags are dependency plumbing.
+func StripWpDep(f string) (string, bool) {
+	const pfx = "-Wp,"
+	if !strings.HasPrefix(f, pfx) {
+		return f, true
+	}
+	// Inside -Wp, the filename is a comma element rather than a separate
+	// argv token, so -MD/-MMD take a value here even though their bare
+	// argv spellings do not. Check the takes-a-value set first.
+	wpTwoArg := map[string]bool{"-MMD": true, "-MD": true, "-MF": true, "-MT": true, "-MQ": true}
+	wpOneArg := map[string]bool{"-M": true, "-MM": true, "-MG": true, "-MP": true}
+
+	parts := strings.Split(f[len(pfx):], ",")
+	var kept []string
+	for i := 0; i < len(parts); i++ {
+		p := parts[i]
+		if wpTwoArg[p] {
+			i++ // the filename rides along as the next comma element
 			continue
 		}
-		if twoArg[f] {
+		if wpOneArg[p] {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if len(kept) == 0 {
+		return "", false
+	}
+	return pfx + strings.Join(kept, ","), true
+}
+
+func stripDepFlags(flags []string) []string {
+	var out []string
+	for i := 0; i < len(flags); i++ {
+		f := flags[i]
+		if depOneArg[f] {
+			continue
+		}
+		if depTwoArg[f] {
 			i++ // skip the value too
 			continue
 		}
-		out = append(out, f)
+		if kept, ok := StripWpDep(f); ok {
+			out = append(out, kept)
+		}
 	}
 	return out
 }

--- a/go/internal/scan/scan.go
+++ b/go/internal/scan/scan.go
@@ -375,12 +375,13 @@ func runScanner(cc, source string, flags []string) (*Result, []depEntry, error) 
 // before -isystem ones. Every TU reaching SmallVector-style code failed
 // with "'struct tm' has no member".
 //
-// "-I." is always first so the staged root is on the include path.
-// Results are deduped by rel path, so a caller's `-I.` (== cwd == root)
-// or a repeated dir does not emit twice.
+// -I order is semantics, not style: the first directory containing
+// the named file wins, so reordering changes which header a TU
+// compiles against. Emit the caller's dirs in their original order,
+// appending a synthetic -I. only if they never named the root.
 func stagedIFlags(projectRoot string, callerDirs []string) []string {
-	iflags := []string{"-I."}
-	seenRel := map[string]bool{".": true}
+	var iflags []string
+	seenRel := map[string]bool{}
 	for _, p := range callerDirs {
 		rel := "."
 		if p != projectRoot {
@@ -394,9 +395,13 @@ func stagedIFlags(projectRoot string, callerDirs []string) []string {
 			continue
 		}
 		seenRel[rel] = true
-		if rel != "." {
-			iflags = append(iflags, "-I"+rel)
-		}
+		iflags = append(iflags, "-I"+rel)
+	}
+	// The staged root has to be reachable even when the caller never
+	// named it — a bare `cc -c foo.c` relies on it. Last, so it cannot
+	// shadow a directory the caller did name.
+	if !seenRel["."] {
+		iflags = append(iflags, "-I.")
 	}
 	return iflags
 }

--- a/go/internal/scan/scan_test.go
+++ b/go/internal/scan/scan_test.go
@@ -228,8 +228,20 @@ func TestStagedIFlags(t *testing.T) {
 		{
 			// Only reachable if projectRoot computation already went
 			// wrong; a visibly-broken flag beats a silently wrong one.
+			// The synthetic "-I." lands LAST here because the caller
+			// never named the root.
 			"dir outside root becomes ..-relative",
-			"/p/sub", []string{"/p/other"}, []string{"-I.", "-I../other"},
+			"/p/sub", []string{"/p/other"}, []string{"-I../other", "-I."},
+		},
+		{
+			// Include ORDER is semantics. kbuild passes the root LAST
+			// (-I../include ... -I../. -I.) so that include/net/nfc/nfc.h
+			// wins over net/nfc/nfc.h. Hoisting "-I." to the front
+			// inverted that and broke net/nfc/af_nfc.c 19,000 compiles
+			// into a kernel build.
+			"caller order is preserved, root stays last",
+			"/p", []string{"/p/include", "/p/net/nfc", "/p"},
+			[]string{"-Iinclude", "-Inet/nfc", "-I."},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/scan/scan_test.go
+++ b/go/internal/scan/scan_test.go
@@ -384,3 +384,33 @@ func TestRunScannerFindsIncbinTargets(t *testing.T) {
 		t.Errorf(".incbin target blob.bin missing from scan result headers: %+v", r.Headers)
 	}
 }
+
+// The kbuild case. `-Wp,-MMD,<file>` redirects dependency output to a
+// file, so a scanner running `gcc -M -MG -MF -` alongside it gets an
+// EMPTY stdout and concludes the TU has no headers. The symptom is a
+// staging tree containing only the .c, and a missing-header error from
+// inside the inner derivation — a long way from the cause.
+func TestStripWpDep(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+		keep bool
+	}{
+		{"kbuild depfile", "-Wp,-MMD,./.helper.o.d", "", false},
+		{"MD form", "-Wp,-MD,dep.d", "", false},
+		{"MF form", "-Wp,-MF,dep.d", "", false},
+		{"valueless forms", "-Wp,-MM,-MG", "", false},
+		{"non-dep -Wp survives", "-Wp,-DFOO=1", "-Wp,-DFOO=1", true},
+		{"mixed keeps the remainder", "-Wp,-MMD,dep.d,-DBAR", "-Wp,-DBAR", true},
+		{"non--Wp flag untouched", "-O2", "-O2", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := StripWpDep(tc.in)
+			if ok != tc.keep || (ok && got != tc.want) {
+				t.Errorf("StripWpDep(%q) = (%q, %v), want (%q, %v)",
+					tc.in, got, ok, tc.want, tc.keep)
+			}
+		})
+	}
+}

--- a/go/internal/shim/archive.go
+++ b/go/internal/shim/archive.go
@@ -176,6 +176,18 @@ func parseARArgs(args []string) (modifiers, archive string, inputs []string, ok 
 	if !isARModifiers(modifiers) {
 		return
 	}
+	// `a`, `b`, `i` and `N` each take a positional argument that follows
+	// the modifier string (`ar rN <count> <archive> <member>...`), which
+	// shifts the archive name one slot right. Their semantics —
+	// insert-relative-to-member, use-instance-N — are member mutations
+	// this shim deliberately does not model.
+	//
+	// Bail explicitly: these were previously rejected only by accident,
+	// via the members-must-end-in-.o check that allowing `.a` members
+	// removes.
+	if strings.ContainsAny(modifiers, "abiN") {
+		return "", "", nil, false
+	}
 	archive = args[1]
 	for _, in := range args[2:] {
 		if !strings.HasSuffix(in, ".o") && !strings.HasSuffix(in, ".a") {

--- a/go/internal/shim/archive.go
+++ b/go/internal/shim/archive.go
@@ -48,6 +48,11 @@ func Archive(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		return RealiseThunkArgsAndPassthrough(cfg, l, realARFor(cfg), args, sandbox.Enabled())
 	}
 
+	if carvedOut(archive) {
+		logf("ar passthrough: %s is in a carved-out subtree", archive)
+		return Passthrough(realARFor(cfg), args)
+	}
+
 	logf("archive %s <- %s", archive, joinBase(inputs))
 
 	if handled, err := tryBatchArchive(cfg, l, archive, modifiers, inputs); handled {

--- a/go/internal/shim/compile.go
+++ b/go/internal/shim/compile.go
@@ -181,7 +181,10 @@ func Compile(tool dispatch.Tool, args []string, cfg *toolchain.Config, l paths.L
 	// diagnostic, so a derivation cannot stand in for either. Checked
 	// before the scan so we don't pay for header discovery we are about
 	// to throw away.
-	if mode.For(source) == mode.Passthrough {
+	// Keyed on the OUTPUT as well as the source: a declared subtree is
+	// about where the object LANDS, and a build may compile a source
+	// from elsewhere into it.
+	if mode.For(source) == mode.Passthrough || mode.For(output) == mode.Passthrough {
 		logf("  passthrough: caller declared this subtree")
 		return Passthrough(realTool, args)
 	}

--- a/go/internal/shim/compile.go
+++ b/go/internal/shim/compile.go
@@ -257,7 +257,14 @@ func Compile(tool dispatch.Tool, args []string, cfg *toolchain.Config, l paths.L
 		tuKey = rel
 	}
 	tuID := stage.TUID(tuKey)
-	if _, err := stage.Sources(l, tuID, entries); err != nil {
+	if sharedStagingEnabled() {
+		_, err = stage.SourcesShared(l, tuID, entries, func(abs string) (string, error) {
+			return storeShared(cfg, abs)
+		})
+	} else {
+		_, err = stage.Sources(l, tuID, entries)
+	}
+	if err != nil {
 		return err
 	}
 

--- a/go/internal/shim/compile.go
+++ b/go/internal/shim/compile.go
@@ -9,8 +9,10 @@
 package shim
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -161,6 +163,16 @@ func Compile(tool dispatch.Tool, args []string, cfg *toolchain.Config, l paths.L
 	// compiler's verdict, so get out of the way.
 	if !isRegularFile(source) {
 		logf("  passthrough: %s is not a regular file (compiler probe)", source)
+		return Passthrough(realTool, args)
+	}
+
+	// `.incbin` embeds a file's bytes at ASSEMBLY time, naming it in a
+	// string the preprocessor never looks at, so `gcc -M` cannot report
+	// it. The file is absent from the staged tree and the TU dies in the
+	// assembler. The named file is usually generated, so it is not a
+	// static dependency the scanner could learn either.
+	if usesIncbin(source) {
+		logf("  passthrough: %s uses .incbin (assembler-time file dependency)", source)
 		return Passthrough(realTool, args)
 	}
 
@@ -876,4 +888,32 @@ func writeSynthesizedDepfile(depfile, output, source string, headers []scan.Head
 func isRegularFile(path string) bool {
 	st, err := os.Stat(path)
 	return err == nil && st.Mode().IsRegular()
+}
+
+// maxIncbinScan caps how much of a source we read looking for .incbin.
+// Real sources are far smaller; the cap only guards against a generated
+// multi-megabyte file making every compile pay to read it.
+const maxIncbinScan = 4 << 20
+
+// usesIncbin reports whether a source contains an .incbin directive.
+//
+// Deliberately a substring search rather than a parse. The directive
+// appears inside a C string literal in inline asm, inside .S files, and
+// behind #ifdefs, so anything short of running the preprocessor and
+// assembler would still be an approximation — and the cost of guessing
+// wrong is asymmetric. A false positive costs one un-accelerated
+// compile; a false negative is a build failure in the assembler, far
+// from the cause.
+func usesIncbin(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	buf := make([]byte, maxIncbinScan)
+	n, err := io.ReadFull(f, buf)
+	if n == 0 && err != nil {
+		return false
+	}
+	return bytes.Contains(buf[:n], []byte(".incbin"))
 }

--- a/go/internal/shim/compile.go
+++ b/go/internal/shim/compile.go
@@ -154,6 +154,16 @@ func Compile(tool dispatch.Tool, args []string, cfg *toolchain.Config, l paths.L
 
 	logf("compile %s -> %s", source, output)
 
+	// A source that is not a regular file cannot be modelled: there are
+	// no bytes to content-address. In practice that means /dev/null,
+	// which is how build systems ask the compiler a question rather
+	// than requesting an artifact — the answer has to be the real
+	// compiler's verdict, so get out of the way.
+	if !isRegularFile(source) {
+		logf("  passthrough: %s is not a regular file (compiler probe)", source)
+		return Passthrough(realTool, args)
+	}
+
 	// Resolve the real cc for scan-headers to match the caller's tool
 	// role — same reason as the passthrough case above.
 	scannerCC := realTool
@@ -856,4 +866,14 @@ func writeSynthesizedDepfile(depfile, output, source string, headers []scan.Head
 	}
 	b.WriteByte('\n')
 	return os.WriteFile(depfile, []byte(b.String()), 0o644)
+}
+
+// isRegularFile reports whether path is a regular file. A symlink to a
+// regular file counts (Stat follows); a character device, fifo or
+// directory does not. Errors count as "not regular" so a source that
+// cannot be stat'd goes to the real compiler, which will produce the
+// caller's expected diagnostic rather than ours.
+func isRegularFile(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && st.Mode().IsRegular()
 }

--- a/go/internal/shim/compile.go
+++ b/go/internal/shim/compile.go
@@ -176,6 +176,16 @@ func Compile(tool dispatch.Tool, args []string, cfg *toolchain.Config, l paths.L
 		return Passthrough(realTool, args)
 	}
 
+	// Subtrees the caller declared as passthrough: their build reads
+	// object BYTES inline, or expects a compile to FAIL and reads the
+	// diagnostic, so a derivation cannot stand in for either. Checked
+	// before the scan so we don't pay for header discovery we are about
+	// to throw away.
+	if mode.For(source) == mode.Passthrough {
+		logf("  passthrough: caller declared this subtree")
+		return Passthrough(realTool, args)
+	}
+
 	// Resolve the real cc for scan-headers to match the caller's tool
 	// role — same reason as the passthrough case above.
 	scannerCC := realTool

--- a/go/internal/shim/compile.go
+++ b/go/internal/shim/compile.go
@@ -488,11 +488,21 @@ func parseCompileArgs(args []string) (source, output, depfile string, flags []st
 			// `-Wp,-MMD,path/to/foo.d` or `-Wp,-MMD,path,-MP` — Kbuild's
 			// own c_flags (scripts/Makefile.lib) always uses this
 			// instead of separate -MD/-MF tokens.
+			//
+			// The depfile path is captured so the shim can still write
+			// the .d the caller expects, then the dependency parts are
+			// stripped: they name a path relative to make's cwd, and the
+			// derivation's cwd is a read-only store path. Anything ELSE
+			// in the same -Wp, group is a real preprocessor flag and has
+			// to survive, which is why this strips rather than drops the
+			// whole argument. scan.StripWpDep is shared with the scanner
+			// so both agree on what counts as dependency plumbing.
 			if p := depfileFromWp(a); p != "" {
 				depfile = p
 			}
-			// Not appended to flags: these target the caller's own
-			// cpp/depfile bookkeeping, meaningless inside the sandbox.
+			if kept, ok := scan.StripWpDep(a); ok {
+				flags = append(flags, kept)
+			}
 		case a == "-x" || a == "-Xlinker" || a == "-Xassembler":
 			// Two-arg forms with values that aren't sources; keep both.
 			if i+1 >= len(args) {

--- a/go/internal/shim/ld.go
+++ b/go/internal/shim/ld.go
@@ -44,13 +44,38 @@ func LD(args []string, cfg *toolchain.Config, l paths.Layout) error {
 	flags, output, inputs, ok := parseLDArgs(args)
 	if !ok {
 		// Not a `-r` partial link, so it is an ordinary full link —
-		// hand it to Link rather than passing through, which is what
-		// keeps a raw `ld` final link (Kbuild's cmd_ld) inside nixgg's
-		// graph. Quiet: this is the overwhelmingly common case and
+		// hand it to Link rather than passing through, which keeps a
+		// raw `ld` final link (Kbuild's cmd_ld) inside nixgg's graph.
+		//
+		// Except in a carved-out subtree. Kbuild runs `ld` with cwd
+		// INSIDE the object directory, so `-o realmode.elf` arrives
+		// bare — and a bare name matches neither passthroughPaths nor
+		// mode.ForLink's own Kbuild carveouts, both of which key on the
+		// full path. The link then gets modelled, arch/x86/tools/relocs
+		// reads the drvref stub back synchronously, and the build dies
+		// with "No ELF magic" — a message that names nothing useful.
+		// Resolve against cwd first so the subtree is visible.
+		if out := ldOutputArg(args); out != "" {
+			if abs, err := filepath.Abs(out); err == nil && carvedOut(abs) {
+				logf("ld passthrough: %s is in a carved-out subtree", out)
+				return Passthrough(real, args)
+			}
+		}
+		// Quiet otherwise: this is the overwhelmingly common case and
 		// logging each one would bury the lines that matter.
 		return Link(dispatch.ToolLD, args, cfg, l)
 	}
 
+	// Same carveout for the `-r` path, where parseLDArgs already gave
+	// us the output. Checked absolute for the same cwd reason.
+	if carvedOut(output) {
+		logf("ld passthrough: %s is in a carved-out subtree", output)
+		return Passthrough(real, args)
+	}
+	if abs, err := filepath.Abs(output); err == nil && carvedOut(abs) {
+		logf("ld passthrough: %s is in a carved-out subtree", output)
+		return Passthrough(real, args)
+	}
 	logf("ld -r %s <- %s", output, joinBase(inputs))
 
 	ci, err, ok := classifyInputs(cfg, inputs, altStorePrefix(cfg.Store), l, "ld",
@@ -185,4 +210,21 @@ var ldTwoArg = map[string]bool{
 	"--architecture": true, "--defsym": true, "--dynamic-linker": true,
 	"--entry": true, "--script": true, "--soname": true, "--wrap": true,
 	"-rpath": true, "--rpath": true, "--undefined": true,
+}
+
+// ldOutputArg pulls the `-o` value out of a raw ld command line.
+//
+// Separate from parseLDArgs, which bails on anything that is not a `-r`
+// link and so cannot report the output for the full-link case — the one
+// place LD needs it to test a carveout before handing off to Link.
+func ldOutputArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "-o" && i+1 < len(args):
+			return args[i+1]
+		case strings.HasPrefix(args[i], "-o") && len(args[i]) > 2:
+			return args[i][2:]
+		}
+	}
+	return ""
 }

--- a/go/internal/shim/ld.go
+++ b/go/internal/shim/ld.go
@@ -1,0 +1,188 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tbereknyei/nixgg/internal/dispatch"
+	"github.com/tbereknyei/nixgg/internal/expr"
+	"github.com/tbereknyei/nixgg/internal/paths"
+	"github.com/tbereknyei/nixgg/internal/sandbox"
+	"github.com/tbereknyei/nixgg/internal/storedeps"
+	"github.com/tbereknyei/nixgg/internal/toolchain"
+	"github.com/tbereknyei/nixgg/internal/wrapperenv"
+)
+
+// LD is the shim entrypoint for `ld`.
+//
+// Only `-r` (partial link: several objects in, one object out) is
+// modelled. A build typically reaches it two ways:
+//
+//	cmd_ld_multi_m = $(LD) $(ld_flags) -r -o $@ @$<
+//	cmd_ld_single  = ; $(LD) $(ld_flags) -r -o $(tmp-target) $@; mv …
+//
+// Both were failing the same way once the compile shim was live —
+// `ld.bfd: algos.o: file format not recognized; treating as linker
+// script`, because ld met a drvref stub.
+//
+// The single-object form needs no special handling: it writes to a temp
+// name and make then `mv`s it over the original. A drvref stub is an
+// ordinary regular file, so the mv carries it across intact and the
+// object ends up pointing at this derivation.
+//
+// Everything that is not a `-r` link passes through. Full links
+// (executables, .so) go through the compiler driver in every build nixgg
+// supports, so modelling them here would duplicate link.go against a
+// second, lower-level command line for no gain.
+func LD(args []string, cfg *toolchain.Config, l paths.Layout) error {
+	real := realLDFor(cfg)
+	if bypassed() || !sandbox.Enabled() {
+		return Passthrough(real, args)
+	}
+
+	flags, output, inputs, ok := parseLDArgs(args)
+	if !ok {
+		// Not a `-r` partial link, so it is an ordinary full link —
+		// hand it to Link rather than passing through, which is what
+		// keeps a raw `ld` final link (Kbuild's cmd_ld) inside nixgg's
+		// graph. Quiet: this is the overwhelmingly common case and
+		// logging each one would bury the lines that matter.
+		return Link(dispatch.ToolLD, args, cfg, l)
+	}
+
+	logf("ld -r %s <- %s", output, joinBase(inputs))
+
+	ci, err, ok := classifyInputs(cfg, inputs, altStorePrefix(cfg.Store), l, "ld",
+		func() error { return Passthrough(real, args) })
+	if !ok {
+		return err
+	}
+
+	wrapperEnvJSON, err := wrapperenv.JSON()
+	if err != nil {
+		return err
+	}
+	wrapperEnv, err := decodeStringMap(wrapperEnvJSON)
+	if err != nil {
+		return err
+	}
+
+	outName := filepath.Base(output)
+	drv := expr.PartialLinkJSON(expr.PartialLinkJSONParams{
+		Name:        "ld-" + outName,
+		OutName:     outName,
+		System:      cfg.System,
+		Bash:        cfg.BashRoot,
+		Coreutils:   cfg.CoreutilsRoot,
+		ToolBin:     real,
+		Flags:       flags,
+		Inputs:      ci.JSON,
+		StoreDeps:   storedeps.From(flags, wrapperEnvJSON, cfg.KnownStorePaths),
+		Placeholder: "/" + expr.OutPlaceholderNix32,
+		ExtraSrcs: []string{
+			baseNameOf(cfg.BashRoot),
+			baseNameOf(cfg.CoreutilsRoot),
+			baseNameOf(ldRootOf(real)),
+		},
+		Env: wrapperEnv,
+	})
+	drvPath, err := sandbox.DerivationAdd(cfg, drv)
+	if err != nil {
+		return err
+	}
+	if err := sandbox.PointOutputAtDrv(output, drvPath); err != nil {
+		return err
+	}
+	logf("  drv:        %s", drvPath)
+	return nil
+}
+
+// parseLDArgs recognises the `ld … -r -o <out> <obj>…` shape and bails
+// on everything else.
+//
+// `-r` must be present: without it this is a full link, which belongs
+// to link.go. `-o` must be present too — ld's default of `a.out` is
+// never what a build system means here, and guessing would put the
+// artifact somewhere nothing looks for it.
+func parseLDArgs(args []string) (flags []string, output string, inputs []string, ok bool) {
+	relocatable := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "-r" || a == "--relocatable":
+			relocatable = true
+			flags = append(flags, a)
+		case a == "-o":
+			if i+1 >= len(args) {
+				return nil, "", nil, false
+			}
+			output = args[i+1]
+			i++
+		case strings.HasPrefix(a, "-o") && len(a) > 2:
+			output = a[2:]
+		case ldTwoArg[a]:
+			// Flags whose value is a separate token. Without this the
+			// value reads as a positional: linker flag sets
+			// starts `-m elf_x86_64`, and "elf_x86_64" is neither an
+			// object nor an archive, so the whole invocation bailed.
+			if i+1 >= len(args) {
+				return nil, "", nil, false
+			}
+			flags = append(flags, a, args[i+1])
+			i++
+		case strings.HasSuffix(a, ".o") || strings.HasSuffix(a, ".a"):
+			inputs = append(inputs, a)
+		case strings.HasPrefix(a, "-"):
+			flags = append(flags, a)
+		default:
+			// A positional that is neither an object nor an archive:
+			// a linker script, a --script value, something we do not
+			// model. Bail rather than silently drop it.
+			return nil, "", nil, false
+		}
+	}
+	if !relocatable || output == "" || len(inputs) == 0 {
+		return nil, "", nil, false
+	}
+	return flags, output, inputs, true
+}
+
+// realLDFor resolves the `ld` this shim stands in for.
+//
+// NIXGG_REAL_LD wins when set: a project may need the UNWRAPPED ld,
+// passes the UNWRAPPED binutils ld there (see common-flags.nix — "The
+// which is not the
+// `ld` sitting next to the compiler.
+//
+// Otherwise fall back to the binutils dir beside the pinned cc, the
+// same place archive.go finds `ar`.
+func realLDFor(cfg *toolchain.Config) string {
+	if v := os.Getenv("NIXGG_REAL_LD"); v != "" {
+		return v
+	}
+	return filepath.Join(filepath.Dir(cfg.RealCC), "ld")
+}
+
+// ldRootOf turns /nix/store/…-binutils/bin/ld into the store root that
+// has to be mounted for it.
+func ldRootOf(ld string) string {
+	return filepath.Dir(filepath.Dir(ld))
+}
+
+// ldTwoArg lists the `ld` options whose value is a separate argv token.
+//
+// Deliberately a fixed list rather than a heuristic: the alternative is
+// guessing from whether the next token looks like a filename, and a
+// wrong guess either swallows an object or leaks a flag value into the
+// input list — both produce a silently wrong object rather than an
+// error. An option missing from here makes parseLDArgs bail into
+// passthrough, which is the safe direction.
+var ldTwoArg = map[string]bool{
+	"-m": true, "-z": true, "-T": true, "-e": true, "-u": true,
+	"-y": true, "-Y": true, "-b": true, "-A": true, "-R": true,
+	"-F": true, "-h": true, "-I": true,
+	"--architecture": true, "--defsym": true, "--dynamic-linker": true,
+	"--entry": true, "--script": true, "--soname": true, "--wrap": true,
+	"-rpath": true, "--rpath": true, "--undefined": true,
+}

--- a/go/internal/shim/ld_test.go
+++ b/go/internal/shim/ld_test.go
@@ -1,0 +1,82 @@
+package shim
+
+import (
+	"reflect"
+	"testing"
+)
+
+// parseLDArgs must recognise both partial-link shapes and
+// nothing else. Full links belong to link.go, which sees the compiler
+// driver's command line rather than ld's.
+func TestParseLDArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantFlags  []string
+		wantOut    string
+		wantInputs []string
+		wantOK     bool
+	}{
+		{
+			// cmd_ld_multi_m, after ExpandRspfiles has flattened the
+			// `@…mod` response file into the member list.
+			name: "multi-object module",
+			args: []string{"-m", "elf_x86_64", "-r", "-o", "raid6_pq.o",
+				"algos.o", "recov.o"},
+			wantFlags:  []string{"-m", "elf_x86_64", "-r"},
+			wantOut:    "raid6_pq.o",
+			wantInputs: []string{"algos.o", "recov.o"},
+			wantOK:     true,
+		},
+		{
+			// cmd_ld_single: one input, temp output, make mv's it back.
+			name:       "single-object module",
+			args:       []string{"-r", "-o", ".tmp_crc4.o", "crc4.o"},
+			wantFlags:  []string{"-r"},
+			wantOut:    ".tmp_crc4.o",
+			wantInputs: []string{"crc4.o"},
+			wantOK:     true,
+		},
+		{
+			name:   "full link is not ours",
+			args:   []string{"-o", "prog", "head.o", "main.o"},
+			wantOK: false,
+		},
+		{
+			name:   "-r without -o bails",
+			args:   []string{"-r", "a.o", "b.o"},
+			wantOK: false,
+		},
+		{
+			name:   "-r with no inputs bails",
+			args:   []string{"-r", "-o", "out.o"},
+			wantOK: false,
+		},
+		{
+			// A linker script or other positional we cannot model:
+			// dropping it silently would produce a wrong object.
+			name:   "unmodellable positional bails",
+			args:   []string{"-r", "-o", "out.o", "a.o", "link.lds"},
+			wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags, out, inputs, ok := parseLDArgs(tc.args)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if out != tc.wantOut {
+				t.Errorf("output = %q, want %q", out, tc.wantOut)
+			}
+			if !reflect.DeepEqual(flags, tc.wantFlags) {
+				t.Errorf("flags = %q, want %q", flags, tc.wantFlags)
+			}
+			if !reflect.DeepEqual(inputs, tc.wantInputs) {
+				t.Errorf("inputs = %q, want %q", inputs, tc.wantInputs)
+			}
+		})
+	}
+}

--- a/go/internal/shim/ldc_test.go
+++ b/go/internal/shim/ldc_test.go
@@ -1,0 +1,52 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tbereknyei/nixgg/internal/mode"
+)
+
+// The two links that killed a 31-minute kernel build: Kbuild runs ld
+// with cwd inside the object dir, so the carveout has to be tested
+// against the resolved path, not the bare `-o` value.
+func TestLDCarveoutResolvesRelativeOutput(t *testing.T) {
+	// SetPassthroughPaths, not the env var: the list is parsed once per
+	// process (mode.ptOnce), so a t.Setenv here is silently ignored
+	// whenever another test in this package has already triggered that
+	// parse — the test then passes alone and fails in a full run.
+	mode.SetPassthroughPaths([]string{
+		"arch/x86/realmode/", "drivers/firmware/efi/libstub/",
+		"arch/x86/entry/vdso/", "arch/x86/purgatory/",
+		"scripts/mod/", "/test_fortify/",
+	})
+	root := t.TempDir()
+	for _, tc := range []struct{ dir, out string }{
+		{"linux-6.18.41/arch/x86/realmode/rm", "realmode.elf"},
+		{"linux-6.18.41/arch/x86/entry/vdso", "vdso64.so"},
+	} {
+		d := filepath.Join(root, tc.dir)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		wd, _ := os.Getwd()
+		if err := os.Chdir(d); err != nil {
+			t.Fatal(err)
+		}
+		got := ldOutputArg([]string{"-m", "elf_x86_64", "-o", tc.out, "a.o"})
+		abs, _ := filepath.Abs(got)
+		carved := carvedOut(abs)
+		bare := carvedOut(got)
+		os.Chdir(wd)
+		if got != tc.out {
+			t.Errorf("ldOutputArg = %q, want %q", got, tc.out)
+		}
+		if bare {
+			t.Errorf("%s: bare name unexpectedly carved out", tc.out)
+		}
+		if !carved {
+			t.Errorf("%s: absolute path NOT carved out — the stub bug is still live", tc.out)
+		}
+	}
+}

--- a/go/internal/shim/objcopy.go
+++ b/go/internal/shim/objcopy.go
@@ -51,6 +51,11 @@ func Objcopy(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		return Passthrough(real, args)
 	}
 
+	if carvedOut(output) {
+		logf("objcopy passthrough: %s is in a carved-out subtree", output)
+		return Passthrough(real, args)
+	}
+
 	logf("objcopy %s <- %s", output, filepath.Base(input))
 
 	outName := filepath.Base(output)

--- a/go/internal/shim/objcopy.go
+++ b/go/internal/shim/objcopy.go
@@ -1,0 +1,144 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tbereknyei/nixgg/internal/classify"
+	"github.com/tbereknyei/nixgg/internal/expr"
+	"github.com/tbereknyei/nixgg/internal/paths"
+	"github.com/tbereknyei/nixgg/internal/sandbox"
+	"github.com/tbereknyei/nixgg/internal/storedeps"
+	"github.com/tbereknyei/nixgg/internal/toolchain"
+)
+
+// Objcopy is the shim entrypoint for `objcopy <flags> <in> <out>`.
+//
+// Objcopy is the shim entrypoint for `objcopy <flags> <in> <out>`.
+//
+// A build step that reads one object and writes another — prefixing
+// symbols, stripping sections. Under nixgg the input is a drvref stub,
+// so the real tool reports "file format not recognized".
+//
+// Same derivation kind as the in-place rewriter, different operand
+// shape: this reads one file and writes another, so nothing has to be
+// copied out of the store first. The binary is normally already a store
+// path, so it needs no store-add step either.
+func Objcopy(args []string, cfg *toolchain.Config, l paths.Layout) error {
+	real := realBinutil(cfg, "NIXGG_REAL_OBJCOPY", "objcopy")
+	if bypassed() || !sandbox.Enabled() {
+		return Passthrough(real, args)
+	}
+
+	flags, input, output, ok := parseObjcopyArgs(args)
+	if !ok {
+		// One-operand (in-place) and read-only forms exist too; we model
+		// neither. Say so — silence here looks identical to acceleration.
+		logf("objcopy passthrough: not an <in> <out> rewrite (%s)", joinBase(args))
+		return Passthrough(real, args)
+	}
+
+	t := classify.Target(input, altStorePrefix(cfg.Store), l)
+	var in expr.JSONDrvInput
+	switch t.Kind {
+	case classify.Drv:
+		in = expr.JSONDrvInput{Kind: "drv", Ref: t.Ref, Name: filepath.Base(input)}
+	case classify.Store:
+		in = expr.JSONDrvInput{Kind: "src", Ref: expr.StoreBasename(t.Ref), Name: filepath.Base(input)}
+	default:
+		logf("objcopy passthrough: can't model input %s (%s)", input, t.Reason())
+		return Passthrough(real, args)
+	}
+
+	logf("objcopy %s <- %s", output, filepath.Base(input))
+
+	outName := filepath.Base(output)
+	drv := expr.TransformJSON(expr.TransformJSONParams{
+		Name:        "oc-" + outName,
+		OutName:     outName,
+		System:      cfg.System,
+		Bash:        cfg.BashRoot,
+		Coreutils:   cfg.CoreutilsRoot,
+		ToolBin:     real,
+		InPlace:     false,
+		Flags:       flags,
+		Input:       in,
+		StoreDeps:   storedeps.From(nil, "", cfg.KnownStorePaths),
+		Placeholder: "/" + expr.OutPlaceholderNix32,
+		ExtraSrcs: []string{
+			baseNameOf(cfg.BashRoot),
+			baseNameOf(cfg.CoreutilsRoot),
+			baseNameOf(toolRootOf(real)),
+		},
+	})
+	drvPath, err := sandbox.DerivationAdd(cfg, drv)
+	if err != nil {
+		return err
+	}
+	if err := sandbox.PointOutputAtDrv(output, drvPath); err != nil {
+		return err
+	}
+	logf("  drv:        %s", drvPath)
+	return nil
+}
+
+// parseObjcopyArgs recognises `objcopy <flags> <infile> <outfile>`.
+//
+// objcopy also accepts a single-operand form that rewrites in place,
+// and read-only uses like --dump-section. Neither is modelled: bail so
+// the real tool runs. Only the two-operand rewrite — the shape
+// scripts/Makefile.lib's cmd_objcopy uses — becomes a derivation.
+func parseObjcopyArgs(args []string) (flags []string, input, output string, ok bool) {
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case objcopyTwoArg[a]:
+			if i+1 >= len(args) {
+				return nil, "", "", false
+			}
+			flags = append(flags, a, args[i+1])
+			i++
+		case strings.HasPrefix(a, "-"):
+			flags = append(flags, a)
+		default:
+			positional = append(positional, a)
+		}
+	}
+	if len(positional) != 2 {
+		return nil, "", "", false
+	}
+	return flags, positional[0], positional[1], true
+}
+
+// objcopyTwoArg lists objcopy options taking a separate value token.
+// Same reasoning as ldTwoArg: an explicit list, because guessing wrong
+// turns a flag value into an operand and silently rewrites the wrong
+// file. Missing entries bail into passthrough.
+var objcopyTwoArg = map[string]bool{
+	"-B": true, "-F": true, "-I": true, "-O": true, "-R": true,
+	"-b": true, "-i": true, "-j": true, "-K": true, "-N": true,
+	"-L": true, "-G": true, "-W": true, "--add-section": true,
+	"--rename-section": true, "--set-section-flags": true,
+	"--remove-section": true, "--only-section": true,
+	"--prefix-symbols": true, "--prefix-alloc-sections": true,
+	"--redefine-sym": true,
+	"--strip-symbol": true, "--keep-symbol": true,
+}
+
+// realBinutil resolves a binutils tool: the named env override wins,
+// otherwise the sibling of the pinned cc — the same bin/ dir archive.go
+// takes `ar` from.
+func realBinutil(cfg *toolchain.Config, envVar, name string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	return filepath.Join(filepath.Dir(cfg.RealCC), name)
+}
+
+// toolRootOf turns /nix/store/…-pkg/bin/tool into the store root that
+// must be mounted for it.
+func toolRootOf(tool string) string {
+	return filepath.Dir(filepath.Dir(tool))
+}

--- a/go/internal/shim/objcopy_test.go
+++ b/go/internal/shim/objcopy_test.go
@@ -1,0 +1,84 @@
+package shim
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The modelled shape is `objcopy <flags> <in> <out>`. Only
+// that two-operand rewrite is modelled; the in-place and read-only
+// forms must bail so the real tool runs.
+func TestParseObjcopyArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantFlags []string
+		wantIn    string
+		wantOut   string
+		wantOK    bool
+	}{
+		{
+			// symbol prefixing with a long flag taking a value
+			// Real STUBCOPY_FLAGS-y use the ATTACHED form.
+			name: "symbol prefixing",
+			args: []string{"--remove-section=.note.gnu.property",
+				"--prefix-alloc-sections=.init", "alignedmem.o", "alignedmem.stub.o"},
+			wantFlags: []string{"--remove-section=.note.gnu.property",
+				"--prefix-alloc-sections=.init"},
+			wantIn: "alignedmem.o", wantOut: "alignedmem.stub.o", wantOK: true,
+		},
+		{
+			name:      "output format override",
+			args:      []string{"-O", "elf32-x86-64", "vdso.so.dbg", "vdso32.so"},
+			wantFlags: []string{"-O", "elf32-x86-64"},
+			wantIn:    "vdso.so.dbg", wantOut: "vdso32.so", wantOK: true,
+		},
+		{
+			// In-place: one operand. Not modelled.
+			name: "single operand bails", args: []string{"-R", ".comment", "foo.o"},
+			wantOK: false,
+		},
+		{
+			name: "no operands bails", args: []string{"--help"}, wantOK: false,
+		},
+		{
+			// Three operands is not a shape we understand.
+			name: "three operands bails", args: []string{"a.o", "b.o", "c.o"},
+			wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags, in, out, ok := parseObjcopyArgs(tc.args)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if in != tc.wantIn || out != tc.wantOut {
+				t.Errorf("in/out = %q/%q, want %q/%q", in, out, tc.wantIn, tc.wantOut)
+			}
+			if !reflect.DeepEqual(flags, tc.wantFlags) {
+				t.Errorf("flags = %q, want %q", flags, tc.wantFlags)
+			}
+		})
+	}
+}
+
+// A long flag whose value is attached with `=` —
+// the attached form, which needs no two-arg handling. This is the exact
+// invocation that first failed with "gdt_idt.o: file format not
+// recognized".
+func TestParseObjcopyArgsAttachedFlags(t *testing.T) {
+	flags, in, out, ok := parseObjcopyArgs(
+		[]string{"--prefix-symbols=__pi_", "gdt_idt.o", "gdt_idt.pi.o"})
+	if !ok {
+		t.Fatal("attached-form flags rejected")
+	}
+	if in != "gdt_idt.o" || out != "gdt_idt.pi.o" {
+		t.Errorf("in/out = %q/%q", in, out)
+	}
+	if len(flags) != 1 || flags[0] != "--prefix-symbols=__pi_" {
+		t.Errorf("flags = %q", flags)
+	}
+}

--- a/go/internal/shim/objtool.go
+++ b/go/internal/shim/objtool.go
@@ -65,6 +65,11 @@ func Objtool(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		return Passthrough(objtoolFallback(real), args)
 	}
 
+	if carvedOut(object) {
+		logf("objtool passthrough: %s is in a carved-out subtree", object)
+		return Passthrough(objtoolFallback(real), args)
+	}
+
 	logf("objtool %s", object)
 
 	toolStore, err := storeAddTool(cfg, "objtool", real)

--- a/go/internal/shim/objtool.go
+++ b/go/internal/shim/objtool.go
@@ -145,13 +145,24 @@ func storeAddTool(cfg *toolchain.Config, name, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cacheDir := os.Getenv("NIX_BUILD_TOP")
+	// Under .nixgg/ so `nixgg assemble` never captures it — see
+	// scratch.go. Only a handful of files today, but the content of each
+	// is a store path, so at the build root they land in the captured
+	// tree's closure like any other memo cache.
 	cache := ""
-	if cacheDir != "" {
-		// Key on the tool's own path: a build may store-add more than
-		// one (objtool today, `ld` for single-object modules next).
-		cache = filepath.Join(cacheDir,
-			fmt.Sprintf(".gg-tool-%s-%x", name, sha256.Sum256([]byte(abs))))
+	if dir, err := scratchDir("tools"); err == nil {
+		// Key on the tool's path AND its mtime+size, matching
+		// storeShared. Path alone is not enough: kbuild rebuilds its own
+		// objtool in place when the config or scripts/ change, and a
+		// path-only key would keep handing derivations the store object
+		// made from the previous binary — objects rewritten by a stale
+		// tool, with no error anywhere.
+		key := abs
+		if st, err := os.Stat(abs); err == nil {
+			key = fmt.Sprintf("%s|%d|%d", abs, st.ModTime().UnixNano(), st.Size())
+		}
+		cache = filepath.Join(dir,
+			fmt.Sprintf("%s-%x", name, sha256.Sum256([]byte(key))))
 		if b, err := os.ReadFile(cache); err == nil {
 			if sp := strings.TrimSpace(string(b)); sp != "" {
 				return sp, nil
@@ -163,8 +174,21 @@ func storeAddTool(cfg *toolchain.Config, name, path string) (string, error) {
 		return "", fmt.Errorf("store-add %s: %w", name, err)
 	}
 	if cache != "" {
-		// Best-effort: a failed write costs a re-add, not correctness.
-		_ = os.WriteFile(cache, []byte(sp), 0o644)
+		// Write to a unique temp and rename. Shims run concurrently
+		// under `make -j` and every object asks for the same key, so a
+		// plain WriteFile lets a reader see a half-written file: the
+		// truncated store path survives TrimSpace and would be used as
+		// ToolBin. Best-effort otherwise — a failed write costs a
+		// re-add, not correctness.
+		if tmp, err := os.CreateTemp(filepath.Dir(cache), ".tool-*"); err == nil {
+			_, werr := tmp.WriteString(sp)
+			cerr := tmp.Close()
+			if werr == nil && cerr == nil {
+				_ = os.Rename(tmp.Name(), cache) // atomic; losing a race is harmless
+			} else {
+				_ = os.Remove(tmp.Name())
+			}
+		}
 	}
 	return sp, nil
 }

--- a/go/internal/shim/objtool.go
+++ b/go/internal/shim/objtool.go
@@ -80,6 +80,7 @@ func Objtool(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		Bash:        cfg.BashRoot,
 		Coreutils:   cfg.CoreutilsRoot,
 		ToolBin:     toolStore,
+		InPlace:     true,
 		Flags:       flags,
 		Input:       in,
 		StoreDeps:   storedeps.From(nil, "", cfg.KnownStorePaths),

--- a/go/internal/shim/objtool.go
+++ b/go/internal/shim/objtool.go
@@ -1,0 +1,180 @@
+package shim
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tbereknyei/nixgg/internal/classify"
+	"github.com/tbereknyei/nixgg/internal/expr"
+	"github.com/tbereknyei/nixgg/internal/paths"
+	"github.com/tbereknyei/nixgg/internal/sandbox"
+	"github.com/tbereknyei/nixgg/internal/storedeps"
+	"github.com/tbereknyei/nixgg/internal/toolchain"
+)
+
+// Objtool is the shim entrypoint for `objtool <flags> foo.o`.
+//
+// It stands for a general shape: a tool that REWRITES an object in
+// place, rather than producing a new artifact from sources. Under nixgg
+// the object is a drvref stub at that moment, so the real tool fails on
+// what looks to it like a corrupt ELF.
+//
+// Modelled as its own derivation: take the producing drv as input, copy
+// its object, rewrite the copy, and leave a fresh stub behind. The ar
+// and link shims already resolve stubs, so nothing else changes.
+//
+// Reached only when the caller points the build's own tool variable at
+// this shim; build systems that pass absolute tool paths defeat PATH
+// interposition, so PATH alone would never route here.
+func Objtool(args []string, cfg *toolchain.Config, l paths.Layout) error {
+	real := os.Getenv("NIXGG_REAL_OBJTOOL")
+	if bypassed() || !sandbox.Enabled() || real == "" {
+		// Native mode has no transform helper, and without the real
+		// binary there is nothing to delegate to. Say so when it is the
+		// missing binary rather than a deliberate bypass: silently
+		// running nothing would corrupt the object.
+		if real == "" && !bypassed() {
+			logf("objtool passthrough: NIXGG_REAL_OBJTOOL unset")
+		}
+		return Passthrough(objtoolFallback(real), args)
+	}
+
+	flags, object, ok := parseObjtoolArgs(args)
+	if !ok {
+		logf("objtool passthrough: no object operand (%s)", joinBase(args))
+		return Passthrough(objtoolFallback(real), args)
+	}
+
+	// The object must be something we can name as a derivation input.
+	// A stub names its producing drv; an already-realised store path is
+	// equally fine. Anything else (a plain file the shims never made)
+	// we cannot model, and passing through would rewrite a file that no
+	// derivation knows about.
+	t := classify.Target(object, altStorePrefix(cfg.Store), l)
+	var in expr.JSONDrvInput
+	switch t.Kind {
+	case classify.Drv:
+		in = expr.JSONDrvInput{Kind: "drv", Ref: t.Ref, Name: filepath.Base(object)}
+	case classify.Store:
+		in = expr.JSONDrvInput{Kind: "src", Ref: expr.StoreBasename(t.Ref), Name: filepath.Base(object)}
+	default:
+		logf("objtool passthrough: can't model input %s (%s)", object, t.Kind)
+		return Passthrough(objtoolFallback(real), args)
+	}
+
+	logf("objtool %s", object)
+
+	toolStore, err := storeAddTool(cfg, "objtool", real)
+	if err != nil {
+		return err
+	}
+
+	outName := filepath.Base(object)
+	drv := expr.TransformJSON(expr.TransformJSONParams{
+		Name:        "ot-" + outName,
+		OutName:     outName,
+		System:      cfg.System,
+		Bash:        cfg.BashRoot,
+		Coreutils:   cfg.CoreutilsRoot,
+		ToolBin:     toolStore,
+		Flags:       flags,
+		Input:       in,
+		StoreDeps:   storedeps.From(nil, "", cfg.KnownStorePaths),
+		Placeholder: "/" + expr.OutPlaceholderNix32,
+		ExtraSrcs: []string{
+			baseNameOf(cfg.BashRoot),
+			baseNameOf(cfg.CoreutilsRoot),
+			baseNameOf(toolStore),
+		},
+	})
+	drvPath, err := sandbox.DerivationAdd(cfg, drv)
+	if err != nil {
+		return err
+	}
+	if err := sandbox.PointOutputAtDrv(object, drvPath); err != nil {
+		return err
+	}
+	logf("  drv:        %s", drvPath)
+	return nil
+}
+
+// parseObjtoolArgs splits objtool's argv into flags and the object it
+// operates on.
+//
+// objtool's grammar is `objtool <actions/options...> file.o` — the
+// object is the sole non-flag operand and comes last. Its options are
+// either bare long flags or `--opt=value` (see its own usage output),
+// so none of them consume a following token, which keeps this parse
+// honest without enumerating them.
+func parseObjtoolArgs(args []string) (flags []string, object string, ok bool) {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			flags = append(flags, a)
+			continue
+		}
+		if object != "" {
+			// A second operand means a shape we do not model.
+			return nil, "", false
+		}
+		object = a
+	}
+	if object == "" {
+		return nil, "", false
+	}
+	return flags, object, true
+}
+
+// storeAddTool puts a binary the wrapped project built itself into the
+// store so a derivation can depend on it.
+//
+// The tool is often built by the build itself, inside the very
+// sandbox we are running in, so it is an ordinary file rather than a
+// store path. `nix store add` fixes that, and because the binary links
+// only against store paths (elfutils/glibc/zlib/zstd) the scan records
+// correct references.
+//
+// The result is memoised in a file beside the build root: every object
+// in the build asks for the same binary, and a fork+exec per object
+// would cost more than the compile derivations it is protecting.
+func storeAddTool(cfg *toolchain.Config, name, path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	cacheDir := os.Getenv("NIX_BUILD_TOP")
+	cache := ""
+	if cacheDir != "" {
+		// Key on the tool's own path: a build may store-add more than
+		// one (objtool today, `ld` for single-object modules next).
+		cache = filepath.Join(cacheDir,
+			fmt.Sprintf(".gg-tool-%s-%x", name, sha256.Sum256([]byte(abs))))
+		if b, err := os.ReadFile(cache); err == nil {
+			if sp := strings.TrimSpace(string(b)); sp != "" {
+				return sp, nil
+			}
+		}
+	}
+	sp, err := sandbox.StoreAddScan(cfg, name, abs)
+	if err != nil {
+		return "", fmt.Errorf("store-add %s: %w", name, err)
+	}
+	if cache != "" {
+		// Best-effort: a failed write costs a re-add, not correctness.
+		_ = os.WriteFile(cache, []byte(sp), 0o644)
+	}
+	return sp, nil
+}
+
+// objtoolFallback picks what Passthrough should exec. Prefer the real
+// binary the caller told us about; otherwise fall back to the name so
+// PATH resolution produces a recognisable "not found" rather than an
+// empty-argv panic.
+func objtoolFallback(real string) string {
+	if real != "" {
+		return real
+	}
+	return "objtool"
+}

--- a/go/internal/shim/objtool_test.go
+++ b/go/internal/shim/objtool_test.go
@@ -1,0 +1,70 @@
+package shim
+
+import (
+	"reflect"
+	"testing"
+)
+
+// parseObjtoolArgs has to hold up against a real invocation,
+// which is one object preceded by a long, config-determined flag list
+// (scripts/Makefile.lib's objtool-args). None of objtool's options take
+// a separate value token — they are bare or `--opt=value` — so the sole
+// non-flag operand is the object.
+func TestParseObjtoolArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantFlags []string
+		wantObj   string
+		wantOK    bool
+	}{
+		{
+			name: "full real-world invocation",
+			args: []string{
+				"--link", "--module", "--ibt", "--orc", "--stackval",
+				"--retpoline", "--rethunk", "--sls", "--static-call",
+				"--uaccess", "--hacks=jump_label,noinstr", "lib/crc/crc4.o",
+			},
+			wantFlags: []string{
+				"--link", "--module", "--ibt", "--orc", "--stackval",
+				"--retpoline", "--rethunk", "--sls", "--static-call",
+				"--uaccess", "--hacks=jump_label,noinstr",
+			},
+			wantObj: "lib/crc/crc4.o",
+			wantOK:  true,
+		},
+		{
+			name: "no flags at all", args: []string{"foo.o"},
+			wantFlags: nil, wantObj: "foo.o", wantOK: true,
+		},
+		{
+			name: "no operand bails", args: []string{"--orc"},
+			wantOK: false,
+		},
+		{
+			// Two operands is a shape we do not model; rewriting only
+			// one of them would silently corrupt the other.
+			name: "two operands bail", args: []string{"--orc", "a.o", "b.o"},
+			wantOK: false,
+		},
+		{
+			name: "empty argv bails", args: nil, wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags, obj, ok := parseObjtoolArgs(tc.args)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if obj != tc.wantObj {
+				t.Errorf("object = %q, want %q", obj, tc.wantObj)
+			}
+			if !reflect.DeepEqual(flags, tc.wantFlags) {
+				t.Errorf("flags = %q, want %q", flags, tc.wantFlags)
+			}
+		})
+	}
+}

--- a/go/internal/shim/probe_test.go
+++ b/go/internal/shim/probe_test.go
@@ -53,3 +53,53 @@ func TestIsRegularFile(t *testing.T) {
 		})
 	}
 }
+
+// .incbin names a file in a string the preprocessor never reads, so
+// `gcc -M` cannot report it and the TU dies in the ASSEMBLER instead.
+//
+// Detection is a substring search by design — the directive appears in C
+// string literals, in .S files, and behind #ifdefs, so anything short of
+// running the preprocessor is an approximation. The costs are asymmetric:
+// a false positive is one un-accelerated compile, a false negative is a
+// build failure far from its cause.
+func TestUsesIncbin(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// Inline asm inside a C source, the common shape.
+	configsC := write("configs.c", `
+#include <linux/init.h>
+asm (
+"	.section \".rodata\", \"a\"		\n"
+"	.global config_data			\n"
+"config_data:					\n"
+"	.incbin \"build/embedded_data.bin\"	\n"
+);
+`)
+	// A bare .S user.
+	initramfsS := write("initramfs_data.S", "	.incbin \"build/payload.bin\"\n")
+	plain := write("plain.c", "int main(void){return 0;}\n")
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"inline asm in C", configsC, true},
+		{"bare .S", initramfsS, true},
+		{"ordinary source", plain, false},
+		{"missing file is not a blocker", filepath.Join(dir, "absent.c"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := usesIncbin(tc.path); got != tc.want {
+				t.Errorf("usesIncbin(%s) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/shim/probe_test.go
+++ b/go/internal/shim/probe_test.go
@@ -1,0 +1,55 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Build systems ask the compiler questions by compiling /dev/null:
+//
+//	$(CC) -Werror $(FLAGS) <option> -c -x c /dev/null -o "$$TMP"
+//
+// The caller keys on the exit status alone, so any error the shim
+// raises reads as "the compiler does not support this option" and the
+// build carries on with a degraded flag set. A non-regular source must
+// never be modelled; pin isRegularFile on the shapes that reach it.
+func TestIsRegularFile(t *testing.T) {
+	dir := t.TempDir()
+
+	real := filepath.Join(dir, "real.c")
+	if err := os.WriteFile(real, []byte("int x;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.c")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	dangling := filepath.Join(dir, "dangling.c")
+	if err := os.Symlink(filepath.Join(dir, "nope.c"), dangling); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"ordinary source", real, true},
+		// Shared staging symlinks staged sources into the store, so a
+		// symlink to a regular file has to keep counting as one.
+		{"symlink to a regular file", link, true},
+		// A character device has no NAR representation, so it cannot be
+		// added to the store at all.
+		{"/dev/null", "/dev/null", false},
+		{"directory", dir, false},
+		{"missing file", filepath.Join(dir, "absent.c"), false},
+		{"dangling symlink", dangling, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRegularFile(tc.path); got != tc.want {
+				t.Errorf("isRegularFile(%s) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/shim/rustc.go
+++ b/go/internal/shim/rustc.go
@@ -163,7 +163,18 @@ func Rustc(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		return fmt.Errorf("stage crate to store: %w", err)
 	}
 
+	// storeDeps is computed BEFORE any spill: once the flags collapse to
+	// a single `@<path>`, the store paths they mentioned are no longer
+	// visible to scan for, and anything they referred to would stop
+	// being mounted.
 	storeDeps := append(storedeps.From(flags, "", cfg.KnownStorePaths), flagDeps...)
+	flags, argfile, err := spillFlagsToArgfile(cfg, flags)
+	if err != nil {
+		return err
+	}
+	if argfile != "" {
+		storeDeps = append(storeDeps, argfile)
+	}
 
 	// 3. Build the drv. The emit names are basenames: every artifact
 	// lands flat in $out, and downstream stubs name it from there.
@@ -700,4 +711,71 @@ func storeFlagFiles(cfg *toolchain.Config, flags []string) ([]string, []string, 
 		deps = append(deps, sp)
 	}
 	return out, deps, nil
+}
+
+// MaxInlineFlagBytes caps how much flag text may be rendered directly
+// into a derivation's build script.
+//
+// The script is one argument to `bash -c`, and the kernel's execve caps
+// a single argument at MAX_ARG_STRLEN — 32 pages, 131072 bytes, a
+// compile-time constant with no runtime knob. Exceeding it fails the
+// builder with "Argument list too long" and nothing that names the
+// flags as the cause.
+//
+// Rust reaches this where C does not. A kernel's generated cfg file is
+// 19,746 lines and 601 KB — one `--cfg=CONFIG_…` per config symbol —
+// and rustc takes it as an @-file precisely so it never has to be a
+// command line. Expanding it inline to model the compile puts all
+// 601 KB back into one argument.
+//
+// Well under the limit, because externs, search paths, emits and the
+// store paths around them share the same argument.
+const MaxInlineFlagBytes = 32 << 10
+
+// spillFlagsToArgfile moves an oversized flag list into a store object
+// and returns the flags replaced by a single `@<path>` referring to it,
+// plus that path so the caller can mount it.
+//
+// This is not a size trick at the expense of correctness: rustc reads
+// @-files one argument per line, the object is content-addressed, and
+// it enters the derivation as an input — so the compile still depends
+// on every flag byte exactly as it did when they were inline. Two
+// crates with identical flags share one object.
+//
+// Below the threshold nothing changes, so small builds keep the legible
+// inline form and their existing drv hashes.
+func spillFlagsToArgfile(cfg *toolchain.Config, flags []string) ([]string, string, error) {
+	n, fits := flagsFitInline(flags)
+	if fits {
+		return flags, "", nil
+	}
+
+	dir, err := os.MkdirTemp(os.Getenv("NIX_BUILD_TOP"), "gg-rustargs-")
+	if err != nil {
+		return nil, "", err
+	}
+	defer os.RemoveAll(dir)
+	// One argument per line, which is the whole of rustc's @-file
+	// grammar — see dispatch.ExpandRustArgfiles.
+	path := filepath.Join(dir, "rustc-args")
+	if err := os.WriteFile(path, []byte(strings.Join(flags, "\n")+"\n"), 0o644); err != nil {
+		return nil, "", err
+	}
+	sp, err := storeAddLooseFile(cfg, path)
+	if err != nil {
+		return nil, "", err
+	}
+	logf("  argfile:    %d flags (%d bytes) -> %s", len(flags), n, sp)
+	return []string{"@" + sp + "/rustc-args"}, sp, nil
+}
+
+// flagsFitInline reports the rendered size of a flag list and whether
+// it may go into the build script directly. Separate from the spill so
+// the boundary can be checked without a store.
+func flagsFitInline(flags []string) (int, bool) {
+	n := 0
+	for _, f := range flags {
+		n += len(f) + 1
+	}
+	return n, n <= MaxInlineFlagBytes
 }

--- a/go/internal/shim/rustc.go
+++ b/go/internal/shim/rustc.go
@@ -178,6 +178,7 @@ func Rustc(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		Externs:   externs,
 		Emits:     emits,
 		StoreDeps: storeDeps,
+		Env:       rustcEnv(res.ProjectRoot, srcStore),
 		ExtraSrcs: []string{
 			baseNameOf(cfg.BashRoot),
 			baseNameOf(cfg.CoreutilsRoot),

--- a/go/internal/shim/rustc.go
+++ b/go/internal/shim/rustc.go
@@ -116,7 +116,13 @@ func Rustc(args []string, cfg *toolchain.Config, l paths.Layout) error {
 	if err != nil {
 		return err
 	}
-	flags := rc.Flags
+	// Flags naming a file the compile reads — a custom target spec —
+	// get their own store object; the scan cannot see them, and the
+	// filename has to survive intact. See storeFlagFiles.
+	flags, flagDeps, err := storeFlagFiles(cfg, rc.Flags)
+	if err != nil {
+		return err
+	}
 
 	srcRel := srcAbs
 	entries := make([]stage.Entry, 0, 1+len(res.Headers))
@@ -157,7 +163,7 @@ func Rustc(args []string, cfg *toolchain.Config, l paths.Layout) error {
 		return fmt.Errorf("stage crate to store: %w", err)
 	}
 
-	storeDeps := storedeps.From(flags, "", cfg.KnownStorePaths)
+	storeDeps := append(storedeps.From(flags, "", cfg.KnownStorePaths), flagDeps...)
 
 	// 3. Build the drv. The emit names are basenames: every artifact
 	// lands flat in $out, and downstream stubs name it from there.
@@ -637,4 +643,61 @@ func writeRustDepFile(path, target, source string, sources []scan.Header) error 
 		return fmt.Errorf("write depfile %s: %w", path, err)
 	}
 	return nil
+}
+
+// rustcFileFlags are flags whose value is a FILE the compile reads, so
+// it has to travel into the derivation like a source.
+//
+// An explicit list, for the reason objcopyTwoArg is one: the value of a
+// flag is not self-identifying, and a wrong guess here either drops a
+// real input or rewrites something that was never a path. The scan
+// cannot find these — rustc's dep-info reports what the CRATE reads,
+// and a target specification is read by the driver before any crate
+// exists.
+//
+//	--target   a custom target spec (`--target=…/scripts/target.json`).
+//	           Also spelled as a builtin triple name, which is not a
+//	           file and is left alone.
+var rustcFileFlags = map[string]bool{"--target": true}
+
+// storeFlagFiles gives each file-valued flag its own store object and
+// rewrites the flag to point there.
+//
+// A store object rather than a staged tree entry, because the FILENAME
+// is load-bearing and staging does not preserve it. rustc names a
+// custom target after its spec file's stem, and `libcore.rmeta` is only
+// loadable by a compile whose target has the same name. Shared staging
+// replaces the staged file with a symlink into a per-file store object
+// named `<hash>-target.json`; rustc follows it and calls the target
+// `<hash>-target`, which matches nothing:
+//
+//	error[E0463]: can't find crate for `core`
+//	  = note: the `pr5ngxn…-target` target may not be installed
+//
+// storeAddLooseFile keeps the basename intact inside its own directory,
+// so the stem stays `target` however the file got there.
+func storeFlagFiles(cfg *toolchain.Config, flags []string) ([]string, []string, error) {
+	out := make([]string, len(flags))
+	copy(out, flags)
+	var deps []string
+	for i, f := range out {
+		name, value, ok := strings.Cut(f, "=")
+		if !ok || !rustcFileFlags[name] {
+			continue
+		}
+		abs, err := filepath.Abs(value)
+		if err != nil || !isRegularFile(abs) {
+			continue
+		}
+		if strings.HasPrefix(abs, "/nix/store/") {
+			continue // already content-addressed and mounted
+		}
+		sp, err := storeAddLooseFile(cfg, abs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("store %s value %s: %w", name, abs, err)
+		}
+		out[i] = name + "=" + filepath.Join(sp, filepath.Base(abs))
+		deps = append(deps, sp)
+	}
+	return out, deps, nil
 }

--- a/go/internal/shim/rustc.go
+++ b/go/internal/shim/rustc.go
@@ -1,0 +1,639 @@
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tbereknyei/nixgg/internal/classify"
+	"github.com/tbereknyei/nixgg/internal/expr"
+	"github.com/tbereknyei/nixgg/internal/mode"
+	"github.com/tbereknyei/nixgg/internal/paths"
+	"github.com/tbereknyei/nixgg/internal/sandbox"
+	"github.com/tbereknyei/nixgg/internal/scan"
+	"github.com/tbereknyei/nixgg/internal/stage"
+	"github.com/tbereknyei/nixgg/internal/storedeps"
+	"github.com/tbereknyei/nixgg/internal/toolchain"
+)
+
+// Rustc is the shim entrypoint for a rustc crate compile.
+//
+// The unit of work is a crate, not a translation unit: one invocation
+// reads a source tree and emits one artifact per `--emit`. Both ends
+// differ from the compile shim, so this shares the staging and drv
+// machinery with it but none of the argv handling.
+//
+// Reached through PATH, unlike every other shim: kbuild's RUSTC
+// defaults to a bare `rustc` and nixpkgs does not override it. That is
+// what realRustc has to guard against.
+func Rustc(args []string, cfg *toolchain.Config, l paths.Layout) error {
+	real, err := realRustc()
+	if err != nil {
+		return err
+	}
+	if bypassed() || !sandbox.Enabled() {
+		return Passthrough(real, args)
+	}
+
+	rc, why, ok := parseRustcArgs(args)
+	if !ok {
+		// Quiet by default: builds ask rustc questions constantly
+		// (`--print file-names`, `--version --verbose`, `-Zunpretty`) and
+		// every one lands here. A non-empty reason means something else —
+		// a command line the parser does not understand — and that must
+		// be visible, or the build quietly never accelerates.
+		if why != "" {
+			logf("rustc passthrough: %s", why)
+		}
+		return Passthrough(real, args)
+	}
+
+	if !isRegularFile(rc.Source) {
+		logf("rustc passthrough: %s is not a regular file", rc.Source)
+		return Passthrough(real, args)
+	}
+
+	// A proc-macro crate's output is dlopen'd by rustc itself when a
+	// dependent crate expands its macros. Defer it and that dependent's
+	// dependency scan goes blind: an unresolvable proc-macro never
+	// expands, so any file it would have pulled in via `include!` is
+	// missing from dep-info and therefore from the staged tree. Leaving
+	// proc-macros as real files on disk is what keeps every other scan
+	// honest. There are few of them and they are host-only.
+	if rc.ProcMacro {
+		logf("rustc passthrough: %s is a proc-macro crate (must be loadable at scan time)", rc.Source)
+		return Passthrough(real, args)
+	}
+
+	if mode.For(rc.Source) == mode.Passthrough {
+		logf("rustc passthrough: caller declared this subtree")
+		return Passthrough(real, args)
+	}
+	for _, e := range rc.Emits {
+		if mode.For(e.Path) == mode.Passthrough || carvedOut(e.Path) {
+			logf("rustc passthrough: %s is in a carved-out subtree", e.Path)
+			return Passthrough(real, args)
+		}
+	}
+
+	logf("rustc %s -> %s", rc.Source, joinBase(rc.emitPaths()))
+
+	externs, ok, err := resolveCrateInputs(cfg, rc, l)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return Passthrough(real, args)
+	}
+
+	// 1. Discover the crate's sources. rustc answers this itself — see
+	// scan.RunRust for why the errors it prints along the way are not a
+	// problem.
+	res, err := scan.RunRust(l, real, rc.Source, rc.ScanFlags)
+	if err != nil {
+		logf("rustc passthrough: scan failed: %v", err)
+		return Passthrough(real, args)
+	}
+
+	// The caller asked rustc for a dep file, and the derivation will not
+	// write one — the emit flags were replaced. kbuild's `if_changed_dep`
+	// runs fixdep over it and hard-fails without it, and the scan already
+	// resolved the exact source set.
+	if rc.DepFile != "" {
+		if err := writeRustDepFile(rc.DepFile, rc.Emits[0].Path, rc.Source, res.Headers); err != nil {
+			return err
+		}
+	}
+
+	// 2. Stage them. The crate root's own staged position is its place
+	// under the project root, exactly like the modules around it —
+	// unless it is already store content, in which case it stays where
+	// it is and is mounted rather than copied. Rust's own `core` is
+	// compiled straight out of the rustc source tree that way.
+	srcAbs, err := filepath.Abs(rc.Source)
+	if err != nil {
+		return err
+	}
+	flags := rc.Flags
+
+	srcRel := srcAbs
+	entries := make([]stage.Entry, 0, 1+len(res.Headers))
+	if !strings.HasPrefix(srcAbs, "/nix/store/") {
+		rel, err := filepath.Rel(res.ProjectRoot, srcAbs)
+		if err != nil {
+			return err
+		}
+		srcRel = rel
+		entries = append(entries, stage.Entry{Abs: srcAbs, Rel: rel})
+	}
+	for _, h := range res.Headers {
+		entries = append(entries, stage.Entry{Abs: h.Abs, Rel: h.Rel})
+	}
+
+	// Key the staging dir on the first emit's project-relative path, the
+	// same rule the compile shim uses: unique across the project, and
+	// identical whatever absolute prefix the build tree sits under.
+	crateKey := rc.Emits[0].Path
+	if abs, err := filepath.Abs(crateKey); err == nil {
+		if rel, err := filepath.Rel(res.ProjectRoot, abs); err == nil && !strings.HasPrefix(rel, "..") {
+			crateKey = rel
+		}
+	}
+	crateID := stage.TUID(crateKey)
+	if sharedStagingEnabled() {
+		_, err = stage.SourcesShared(l, crateID, entries, func(abs string) (string, error) {
+			return storeShared(cfg, abs)
+		})
+	} else {
+		_, err = stage.Sources(l, crateID, entries)
+	}
+	if err != nil {
+		return err
+	}
+	srcStore, err := sandbox.StoreAddScan(cfg, crateID, filepath.Join(l.Srcs, crateID))
+	if err != nil {
+		return fmt.Errorf("stage crate to store: %w", err)
+	}
+
+	storeDeps := storedeps.From(flags, "", cfg.KnownStorePaths)
+
+	// 3. Build the drv. The emit names are basenames: every artifact
+	// lands flat in $out, and downstream stubs name it from there.
+	emits := make([]expr.RustEmit, 0, len(rc.Emits))
+	for _, e := range rc.Emits {
+		emits = append(emits, expr.RustEmit{Kind: e.Kind, Name: filepath.Base(e.Path)})
+	}
+	name := "rs-" + filepath.Base(rc.Emits[0].Path)
+	drv := expr.RustcJSON(expr.RustcJSONParams{
+		Name:      name,
+		System:    cfg.System,
+		Bash:      cfg.BashRoot,
+		Coreutils: cfg.CoreutilsRoot,
+		RustcBin:  real,
+		SrcStore:  srcStore,
+		Source:    srcRel,
+		Flags:     flags,
+		Externs:   externs,
+		Emits:     emits,
+		StoreDeps: storeDeps,
+		ExtraSrcs: []string{
+			baseNameOf(cfg.BashRoot),
+			baseNameOf(cfg.CoreutilsRoot),
+			baseNameOf(toolRootOf(real)),
+			baseNameOf(srcStore),
+		},
+	})
+	drvPath, err := sandbox.DerivationAdd(cfg, drv)
+	if err != nil {
+		return err
+	}
+
+	// 4. One stub per emit, all naming the same drv. A consumer resolves
+	// the stub to the drv and reaches its own artifact by filename
+	// inside that output — which is why the metadata a dependent crate
+	// resolves `--extern` against needs no derivation of its own.
+	for _, e := range rc.Emits {
+		if err := sandbox.PointOutputAtDrv(e.Path, drvPath); err != nil {
+			return err
+		}
+	}
+	logf("  drv:        %s", drvPath)
+	return nil
+}
+
+// rustcEmit is one `--emit=<kind>=<path>` the caller asked for.
+type rustcEmit struct {
+	Kind string
+	Path string
+}
+
+// rustcCall is a parsed rustc command line, reduced to what a
+// derivation needs: the crate root, the artifacts to emit, the
+// dependencies to bind, and everything else passed through.
+type rustcCall struct {
+	Source  string
+	Emits   []rustcEmit
+	Externs []rustcExtern
+	// LibDirs are the caller's `-L [KIND=]PATH` search dirs, used to
+	// resolve a bare `--extern <crate>` to a file. They do not survive
+	// into the derivation: the dirs are the build tree.
+	LibDirs []string
+	// Flags is everything not consumed above, in the caller's order.
+	Flags []string
+	// ScanFlags is the caller's argv verbatim, minus the source. The
+	// dependency scan needs the ORIGINAL command line, not the reduced
+	// one: a scan without `-L` and `--extern` cannot resolve `core`
+	// under `--sysroot=/dev/null`, and rustc then fails at the driver
+	// level, before it writes any dep-info at all.
+	ScanFlags []string
+	ProcMacro bool
+	// DepFile is the `--emit=dep-info=<path>` the caller asked for, if
+	// any. Written by the shim rather than the derivation.
+	DepFile string
+}
+
+type rustcExtern struct {
+	Crate string
+	Path  string // empty when the caller left it to -L resolution
+}
+
+func (rc *rustcCall) emitPaths() []string {
+	out := make([]string, 0, len(rc.Emits))
+	for _, e := range rc.Emits {
+		out = append(out, e.Path)
+	}
+	return out
+}
+
+// rustcSeparatedFlags take their value as the NEXT argv element rather
+// than after an `=`.
+//
+// An explicit list, and its completeness matters more than it looks. A
+// separated flag missing from here leaves its value looking like a bare
+// operand, the parser sees two positionals where it expects one, and
+// the whole invocation drops to passthrough. That fails SAFE — the
+// build runs unaccelerated rather than wrong — but it is invisible, so
+// it costs a full build to notice. `--remap-path-prefix` is here
+// because it cost exactly that.
+//
+// Short options rustc also accepts attached (-Copt-level=2) appear
+// here in their separated spelling; the attached form is handled by
+// prefix.
+var rustcSeparatedFlags = map[string]bool{
+	"--emit": true, "--extern": true, "-L": true, "-o": true,
+	"--out-dir": true, "--crate-type": true, "--print": true,
+	"--sysroot": true, "--target": true, "--crate-name": true,
+	"--edition": true, "--cfg": true, "--check-cfg": true,
+	"--cap-lints": true, "--error-format": true, "--json": true,
+	"--color": true, "--diagnostic-width": true, "--explain": true,
+	"--remap-path-prefix": true, "--env-set": true, "--extern-location": true,
+	"--codegen": true, "--allow": true, "--warn": true,
+	"--deny": true, "--forbid": true,
+	"-C": true, "-Z": true, "-W": true, "-A": true, "-D": true,
+	"-F": true, "-l": true,
+}
+
+// parseRustcArgs recognises a crate compile whose artifacts are all
+// named explicitly, and rejects everything else.
+//
+// Naming is the whole test. `--emit=obj` without a path leaves rustc to
+// choose the filename from the crate name and type, and a derivation
+// cannot write a stub for a file it cannot name. Builds that do this
+// pair it with `--out-dir`, so they are asking for a directory of
+// artifacts rather than a set of known ones — a different shape, not
+// modelled here.
+//
+// Also rejected: `--print` and `--version` (questions, not artifacts —
+// a build runs several before compiling anything), `-Zunpretty` (writes
+// to stdout), and `-` as the source (stdin).
+//
+// The returned reason distinguishes the two kinds of rejection.
+// "Question" invocations are expected and constant; anything else means
+// a command line this parser does not understand, and the caller says
+// so — a silent bail there is a build that quietly never accelerates.
+func parseRustcArgs(args []string) (*rustcCall, string, bool) {
+	rc := &rustcCall{}
+	var positional []string
+	positionalAt := map[int]bool{}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case rustcSeparatedFlags[a]:
+			if i+1 >= len(args) {
+				return nil, "", false
+			}
+			if !rc.takeFlag(a, args[i+1]) {
+				return nil, "", false
+			}
+			i++
+		case strings.HasPrefix(a, "--"):
+			eq := strings.IndexByte(a, '=')
+			if eq < 0 {
+				if !rc.takeFlag(a, "") {
+					return nil, "", false
+				}
+				continue
+			}
+			if !rc.takeFlag(a[:eq], a[eq+1:]) {
+				return nil, "", false
+			}
+		case strings.HasPrefix(a, "-") && len(a) > 1:
+			// Attached short option (-Cfoo, -Zbar, -Lpath).
+			if !rc.takeFlag(a[:2], a[2:]) {
+				return nil, "", false
+			}
+		default:
+			positional = append(positional, a)
+			positionalAt[i] = true
+		}
+	}
+	if len(positional) == 1 && positional[0] == "-" {
+		return nil, "", false // stdin: a probe, not a crate
+	}
+	if len(rc.Emits) == 0 {
+		return nil, "", false
+	}
+	if len(positional) != 1 {
+		// More than one operand means a separated flag's value was taken
+		// for a source — see rustcSeparatedFlags. Name them: this is the
+		// one bail that indicates a gap here rather than an invocation we
+		// deliberately ignore.
+		return nil, fmt.Sprintf("expected one source, got %d operands (%v) — "+
+			"a two-argument flag is probably missing from rustcSeparatedFlags",
+			len(positional), positional), false
+	}
+	rc.Source = positional[0]
+	for i, a := range args {
+		if !positionalAt[i] {
+			rc.ScanFlags = append(rc.ScanFlags, a)
+		}
+	}
+	return rc, "", true
+}
+
+// takeFlag consumes one flag and its value, returning false when the
+// flag means this invocation cannot be modelled at all.
+//
+// value == "" means the flag stood alone on the command line.
+func (rc *rustcCall) takeFlag(flag, value string) bool {
+	switch flag {
+	case "--print", "--version", "-V", "--help":
+		return false
+	case "-o", "--out-dir":
+		// Replaced by the derivation's own output layout.
+		return true
+	case "--emit":
+		// A comma-separated list of `kind[=path]`. dep-info is the
+		// build's own bookkeeping and is regenerated below; every other
+		// kind must name its file.
+		for _, spec := range strings.Split(value, ",") {
+			kind, path, named := strings.Cut(spec, "=")
+			if kind == "dep-info" {
+				// Not an artifact: the build's own bookkeeping, which the
+				// shim writes itself from the scan.
+				rc.DepFile = path
+				continue
+			}
+			if !named || path == "" {
+				return false
+			}
+			rc.Emits = append(rc.Emits, rustcEmit{Kind: kind, Path: path})
+		}
+		return true
+	case "--extern":
+		crate, path, _ := strings.Cut(value, "=")
+		rc.Externs = append(rc.Externs, rustcExtern{Crate: crate, Path: path})
+		return true
+	case "-L":
+		// `-L [KIND=]PATH`; KIND is one of dependency/crate/native/….
+		dir := value
+		if _, rest, ok := strings.Cut(value, "="); ok {
+			dir = rest
+		}
+		rc.LibDirs = append(rc.LibDirs, dir)
+		return true
+	case "--crate-type":
+		if value == "proc-macro" {
+			rc.ProcMacro = true
+		}
+		rc.Flags = append(rc.Flags, flag, value)
+		return true
+	case "-Z":
+		if strings.HasPrefix(value, "unpretty") {
+			return false
+		}
+		rc.Flags = append(rc.Flags, flag+value)
+		return true
+	case "-C", "-W", "-A", "-D", "-F", "-l":
+		// Short options rustc accepts attached or separated; emit the
+		// attached form so both spellings produce the same derivation.
+		rc.Flags = append(rc.Flags, flag+value)
+		return true
+	}
+	if value == "" {
+		rc.Flags = append(rc.Flags, flag)
+	} else {
+		rc.Flags = append(rc.Flags, flag+"="+value)
+	}
+	return true
+}
+
+// resolveCrateInputs turns the crates this compile can reach into
+// derivation inputs: the ones the caller named with `--extern`, plus
+// every crate sitting in its `-L` search dirs.
+//
+// The named ones are resolved here rather than in the sandbox because
+// the `-L` dirs rustc would search are the build tree: absent there,
+// and holding drvref stubs outside it.
+//
+// The unnamed ones are needed because a crate's own dependencies travel
+// in its metadata, not on the command line — a kernel driver names two
+// externs and rustc then loads ten crates. Nothing on the command line
+// says which, so every crate in the search dirs comes along.
+//
+// That over-approximates: a crate that happens to sit next to a real
+// dependency becomes an input too, so touching it rebuilds compiles
+// that never read it. The alternative is asking rustc, which only
+// answers under `-Zbinary_dep_depinfo=y` — a flag the caller may not
+// pass and that this shim cannot add on stable. Search dirs hold a
+// project's own crates and little else, so the cost is a few extra
+// edges, not a rebuild storm.
+//
+// A crate that cannot be modelled fails the whole invocation into
+// passthrough rather than being dropped. Dropping one would produce a
+// derivation that compiles against a dependency Nix does not know
+// about — which fails inside the sandbox, naming the crate rather than
+// the missing edge.
+func resolveCrateInputs(cfg *toolchain.Config, rc *rustcCall, l paths.Layout) ([]expr.JSONDrvInput, bool, error) {
+	var out []expr.JSONDrvInput
+	seen := map[string]bool{}
+
+	add := func(path, crate string) bool {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			abs = path
+		}
+		if seen[abs] && crate == "" {
+			return true // already pulled in as a search-path entry
+		}
+		seen[abs] = true
+
+		c := classify.Target(path, altStorePrefix(cfg.Store), l)
+		switch c.Kind {
+		case classify.Drv:
+			out = append(out, expr.JSONDrvInput{
+				Kind: "drv", Ref: c.Ref, Name: filepath.Base(path), Crate: crate,
+			})
+		case classify.Store:
+			out = append(out, expr.JSONDrvInput{
+				Kind: "src", Ref: expr.StoreBasename(c.Ref), Name: filepath.Base(path), Crate: crate,
+			})
+		case classify.Regular:
+			// A crate nixgg did not produce — a proc-macro left as a real
+			// file, or one built before the shims were on PATH. Store it
+			// and depend on its content, for the same reason
+			// classifyInputs does: bailing would make this crate
+			// passthrough, hence a plain file, making every crate above it
+			// unmodellable in turn.
+			sp, err := storeAddLooseFile(cfg, path)
+			if err != nil {
+				logf("  passthrough: store-add %s failed: %v", path, err)
+				return false
+			}
+			out = append(out, expr.JSONDrvInput{
+				Kind: "src", Ref: filepath.Base(sp), Name: filepath.Base(path), Crate: crate,
+			})
+		default:
+			logf("  passthrough: can't model crate %s (%s)", path, c.Reason())
+			return false
+		}
+		return true
+	}
+
+	for _, ex := range rc.Externs {
+		path := ex.Path
+		if path == "" {
+			p, ok := findCrateFile(rc.LibDirs, ex.Crate)
+			if !ok {
+				logf("  passthrough: no file for --extern %s in %v", ex.Crate, rc.LibDirs)
+				return nil, false, nil
+			}
+			path = p
+		}
+		if !add(path, ex.Crate) {
+			return nil, false, nil
+		}
+	}
+	for _, p := range crateFilesIn(rc.LibDirs) {
+		if !add(p, "") {
+			return nil, false, nil
+		}
+	}
+	return out, true, nil
+}
+
+// crateFilesIn lists every crate file in the given search dirs, in a
+// deterministic order — the drv's content depends on it.
+func crateFilesIn(dirs []string) []string {
+	var out []string
+	for _, d := range dirs {
+		entries, err := os.ReadDir(d)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			n := e.Name()
+			if !strings.HasPrefix(n, "lib") || e.IsDir() {
+				continue
+			}
+			if strings.HasSuffix(n, ".rlib") || strings.HasSuffix(n, ".rmeta") ||
+				strings.HasSuffix(n, ".so") {
+				out = append(out, filepath.Join(d, n))
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// findCrateFile mirrors rustc's own search for a bare `--extern
+// <crate>`: each -L dir in order, rlib before rmeta before dylib.
+func findCrateFile(dirs []string, crate string) (string, bool) {
+	for _, d := range dirs {
+		for _, ext := range []string{".rlib", ".rmeta", ".so"} {
+			p := filepath.Join(d, "lib"+crate+ext)
+			if st, err := os.Stat(p); err == nil && st.Mode().IsRegular() {
+				return p, true
+			}
+		}
+	}
+	return "", false
+}
+
+// realRustc resolves the compiler this shim stands in for.
+//
+// Unlike every other shim, this one is normally reached through PATH
+// rather than an explicit `RUSTC=` — kbuild's default is a bare
+// `rustc`, and nixpkgs does not override it. So the fallback cannot be
+// a PATH lookup for "rustc": that finds this shim again and the build
+// forks until it dies. Skip any candidate that is this executable.
+//
+// There is no sibling-of-cc fallback either. A Rust build pins its
+// toolchain — crate metadata can only be read by the rustc that wrote
+// it — so guessing is not a recoverable error.
+func realRustc() (string, error) {
+	if v := os.Getenv("NIXGG_REAL_RUSTC"); v != "" {
+		return v, nil
+	}
+	// Bail rather than guess. If we cannot identify our own executable
+	// we cannot recognise ourselves on PATH either, and the first
+	// candidate we would return is ${nixgg}/shims/rustc — this binary.
+	// The old code let both os.Executable and EvalSymlinks fail into
+	// self=="", which matches no candidate, so it returned exactly that
+	// shim and the build forked until it died.
+	self, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("rustc shim: cannot determine own path (%w); "+
+			"refusing to search PATH, which would resolve back to this shim — set NIXGG_REAL_RUSTC", err)
+	}
+	// A failure here is not fatal: keep the unresolved path, which is
+	// still a usable identity for os.SameFile below.
+	if resolved, rerr := filepath.EvalSymlinks(self); rerr == nil {
+		self = resolved
+	}
+	selfInfo, _ := os.Stat(self)
+
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		cand := filepath.Join(dir, "rustc")
+		st, serr := os.Stat(cand)
+		if serr != nil || st.IsDir() || st.Mode()&0o111 == 0 {
+			continue
+		}
+		// Two independent identity checks. SameFile compares device and
+		// inode, so it catches a hardlink or a differently-spelled path
+		// to the same binary; the EvalSymlinks comparison catches the
+		// symlink farm mkNixggBuild actually lays out.
+		if selfInfo != nil && os.SameFile(st, selfInfo) {
+			continue
+		}
+		if resolved, rerr := filepath.EvalSymlinks(cand); rerr == nil && resolved == self {
+			continue
+		}
+		return cand, nil
+	}
+	// Deliberately an error, not a bare "rustc". Returning the literal
+	// would be re-resolved through PATH by exec — finding this shim
+	// again, which is the very thing the loop above rules out.
+	return "", fmt.Errorf("rustc shim: no rustc on PATH other than this shim; set NIXGG_REAL_RUSTC")
+}
+
+// writeRustDepFile emits the make-format fragment rustc would have
+// written, reconstructed from the scan.
+//
+// Same shape as the compile shim's: `target: prereq…`, and the same
+// reasoning about what consumes it. Store-path dependencies are absent
+// because the scan drops them — they are immutable, so a rebuild
+// trigger on them would never fire anyway.
+func writeRustDepFile(path, target, source string, sources []scan.Header) error {
+	var b strings.Builder
+	b.WriteString(target)
+	b.WriteString(": ")
+	b.WriteString(source)
+	for _, s := range sources {
+		b.WriteString(" \\\n  ")
+		b.WriteString(s.Abs)
+	}
+	b.WriteString("\n")
+
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("depfile dir %s: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("write depfile %s: %w", path, err)
+	}
+	return nil
+}

--- a/go/internal/shim/rustc_test.go
+++ b/go/internal/shim/rustc_test.go
@@ -269,6 +269,32 @@ func TestParseRustcArgsKeepsScanFlags(t *testing.T) {
 	}
 }
 
+// A kernel's generated cfg file is 19,746 lines and 601 KB — one
+// `--cfg=CONFIG_…` per config symbol. rustc takes it as an @-file
+// precisely so it never has to be a command line; expanding it inline
+// to model the compile puts all 601 KB into the single `bash -c`
+// argument the builder runs, and execve caps that at MAX_ARG_STRLEN
+// (32 pages, 131072 bytes, a compile-time kernel constant with no
+// runtime knob). The builder then dies with "Argument list too long"
+// and nothing that names the flags as the cause.
+func TestFlagsFitInline(t *testing.T) {
+	if _, fits := flagsFitInline([]string{"--edition=2021", "-Cpanic=abort"}); !fits {
+		t.Error("an ordinary flag list must stay inline; spilling it would move every drv hash")
+	}
+
+	var kernelCfg []string
+	for i := 0; i < 19746; i++ {
+		kernelCfg = append(kernelCfg, `--cfg=CONFIG_SOME_LONGISH_SYMBOL_NAME="m"`)
+	}
+	n, fits := flagsFitInline(kernelCfg)
+	if n < 600_000 {
+		t.Fatalf("fixture is %d bytes; the real kernel cfg file is ~601 KB", n)
+	}
+	if fits {
+		t.Errorf("a %d-byte flag list was judged inlineable, %d over MAX_ARG_STRLEN", n, n-131072)
+	}
+}
+
 // A builtin target triple is not a file and must be left alone.
 // Rewriting it would turn a valid target into a missing path, and
 // store-adding it is meaningless.

--- a/go/internal/shim/rustc_test.go
+++ b/go/internal/shim/rustc_test.go
@@ -268,3 +268,31 @@ func TestParseRustcArgsKeepsScanFlags(t *testing.T) {
 		}
 	}
 }
+
+// A builtin target triple is not a file and must be left alone.
+// Rewriting it would turn a valid target into a missing path, and
+// store-adding it is meaningless.
+func TestStoreFlagFilesLeavesTripleAlone(t *testing.T) {
+	in := []string{"--target=x86_64-unknown-none", "--edition=2021"}
+	flags, deps, err := storeFlagFiles(nil, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(flags, in) || len(deps) != 0 {
+		t.Errorf("flags = %q deps = %v; want unchanged", flags, deps)
+	}
+}
+
+// A spec already in the store keeps its path: it is content-addressed
+// and mounted already, and re-adding it would change the filename rustc
+// derives the target NAME from.
+func TestStoreFlagFilesSkipsStorePaths(t *testing.T) {
+	in := []string{"--target=/nix/store/aaa-spec/target.json"}
+	flags, deps, err := storeFlagFiles(nil, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(flags, in) || len(deps) != 0 {
+		t.Errorf("flags = %q deps = %v; want unchanged", flags, deps)
+	}
+}

--- a/go/internal/shim/rustc_test.go
+++ b/go/internal/shim/rustc_test.go
@@ -1,0 +1,270 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// The kernel's own two rustc command shapes, since they are the only
+// ones this has been exercised against and their differences are the
+// interesting ones: `cmd_rustc_o_rs` emits an object alone, while
+// `cmd_rustc_library` also emits the metadata every dependent crate
+// resolves `--extern` against.
+func TestParseRustcArgsKernelShapes(t *testing.T) {
+	t.Run("cmd_rustc_o_rs", func(t *testing.T) {
+		rc, _, ok := parseRustcArgs([]string{
+			"--edition=2021", "-Zallow-features=asm_const", "-Zcrate-attr=no_std",
+			"--extern", "pin_init", "--extern", "kernel",
+			"--crate-type", "rlib", "-L", "rust/",
+			"--crate-name", "drm_panic_qr", "--sysroot=/dev/null",
+			"--out-dir", "drivers/gpu/drm", "--emit=dep-info=.qr.d",
+			"--emit=obj=drivers/gpu/drm/drm_panic_qr.o",
+			"drivers/gpu/drm/drm_panic_qr.rs",
+		})
+		if !ok {
+			t.Fatal("did not parse")
+		}
+		if rc.Source != "drivers/gpu/drm/drm_panic_qr.rs" {
+			t.Errorf("Source = %q", rc.Source)
+		}
+		want := []rustcEmit{{Kind: "obj", Path: "drivers/gpu/drm/drm_panic_qr.o"}}
+		if !reflect.DeepEqual(rc.Emits, want) {
+			t.Errorf("Emits = %+v, want %+v (dep-info is the build's own bookkeeping)", rc.Emits, want)
+		}
+		if len(rc.Externs) != 2 || rc.Externs[0].Crate != "pin_init" || rc.Externs[0].Path != "" {
+			t.Errorf("Externs = %+v; bare form must survive parsing for -L resolution", rc.Externs)
+		}
+		if !reflect.DeepEqual(rc.LibDirs, []string{"rust/"}) {
+			t.Errorf("LibDirs = %v", rc.LibDirs)
+		}
+		// -L and --out-dir describe the build tree, which the sandbox does
+		// not have. They must not reach the derivation.
+		for _, f := range rc.Flags {
+			if f == "-Lrust/" || f == "rust/" || f == "--out-dir" {
+				t.Errorf("build-tree flag %q leaked into the derivation flags: %v", f, rc.Flags)
+			}
+		}
+	})
+
+	t.Run("cmd_rustc_library emits metadata too", func(t *testing.T) {
+		rc, _, ok := parseRustcArgs([]string{
+			"--emit=dep-info=.kernel.d", "--emit=obj=rust/kernel.o",
+			"--emit=metadata=rust/libkernel.rmeta",
+			"--crate-type", "rlib", "-Lrust",
+			"--crate-name", "kernel", "rust/kernel/lib.rs",
+			"--sysroot=/dev/null", "-Zunstable-options",
+		})
+		if !ok {
+			t.Fatal("did not parse")
+		}
+		want := []rustcEmit{
+			{Kind: "obj", Path: "rust/kernel.o"},
+			{Kind: "metadata", Path: "rust/libkernel.rmeta"},
+		}
+		if !reflect.DeepEqual(rc.Emits, want) {
+			t.Errorf("Emits = %+v, want %+v", rc.Emits, want)
+		}
+	})
+}
+
+// Everything that must NOT become a derivation. Each of these runs
+// during a normal kernel build, several times, before any crate is
+// compiled — modelling one would either hang the build waiting for an
+// answer it prints to stdout, or write a stub where a real file has to
+// be.
+func TestParseRustcArgsRejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"--print asks a question", []string{
+			"--print", "file-names", "--crate-name", "macros",
+			"--crate-type", "proc-macro", "-"}},
+		{"--version asks a question", []string{"--version", "--verbose"}},
+		{"unpretty writes to stdout", []string{
+			"-Zunpretty=expanded", "--emit=obj=x.o", "x.rs"}},
+		{"stdin source", []string{"--emit=obj=x.o", "-"}},
+		{"unnamed emit", []string{"--emit=obj", "--out-dir", "rust", "x.rs"}},
+		{"no emit at all", []string{"--crate-type", "rlib", "x.rs"}},
+		{"two sources", []string{"--emit=obj=x.o", "a.rs", "b.rs"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, ok := parseRustcArgs(tc.args); ok {
+				t.Errorf("parsed %v; expected a bail into passthrough", tc.args)
+			}
+		})
+	}
+}
+
+// A proc-macro crate has to stay a real file: rustc dlopen's it to
+// expand a dependent crate's macros, including during that crate's
+// dependency scan. Deferring it makes every downstream scan silently
+// incomplete rather than failing.
+func TestParseRustcArgsFlagsProcMacro(t *testing.T) {
+	rc, _, ok := parseRustcArgs([]string{
+		"--crate-type", "proc-macro", "--crate-name", "macros",
+		"--emit=link=rust/libmacros.so", "rust/macros/lib.rs",
+	})
+	if !ok {
+		t.Fatal("did not parse")
+	}
+	if !rc.ProcMacro {
+		t.Error("proc-macro crate not flagged; it would be deferred and every dependent scan would go blind")
+	}
+}
+
+// Attached and separated spellings of the same option must produce the
+// same derivation flags, or the same compile gets two drv hashes
+// depending on how the caller happened to write it.
+func TestParseRustcArgsNormalisesShortOptions(t *testing.T) {
+	sep, _, ok1 := parseRustcArgs([]string{"-C", "opt-level=2", "--emit=obj=x.o", "x.rs"})
+	att, _, ok2 := parseRustcArgs([]string{"-Copt-level=2", "--emit=obj=x.o", "x.rs"})
+	if !ok1 || !ok2 {
+		t.Fatal("did not parse")
+	}
+	if !reflect.DeepEqual(sep.Flags, att.Flags) {
+		t.Errorf("separated %v != attached %v", sep.Flags, att.Flags)
+	}
+}
+
+// This shim is the only one normally reached through PATH rather than an
+// explicit tool= assignment: kbuild's default is a bare `rustc` and
+// nixpkgs does not override it. So the PATH fallback must not find the
+// shim again — that forks the build until it dies, with no error naming
+// the cause.
+func TestRealRustcSkipsItself(t *testing.T) {
+	dir := t.TempDir()
+	self, err := os.Executable()
+	if err != nil {
+		t.Skip("no executable path available")
+	}
+	self, err = filepath.EvalSymlinks(self)
+	if err != nil {
+		t.Skip("cannot resolve own path")
+	}
+	// A shims/ dir on PATH, exactly as mkNixggBuild lays it out.
+	shim := filepath.Join(dir, "rustc")
+	if err := os.Symlink(self, shim); err != nil {
+		t.Skip("cannot symlink")
+	}
+	real := filepath.Join(t.TempDir(), "rustc")
+	if err := os.WriteFile(real, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NIXGG_REAL_RUSTC", "")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+filepath.Dir(real))
+
+	got, err := realRustc()
+	if err != nil {
+		t.Fatalf("realRustc() error: %v", err)
+	}
+	if got != real {
+		t.Errorf("realRustc() = %q, want %q — resolving to the shim itself forks forever", got, real)
+	}
+}
+
+// The dep file is the build's, not the derivation's. kbuild's
+// `if_changed_dep` runs fixdep over it and hard-fails when it is
+// missing, and the derivation cannot write it — the emit flags were
+// replaced with the derivation's own.
+func TestParseRustcArgsRemembersDepFile(t *testing.T) {
+	rc, _, ok := parseRustcArgs([]string{
+		"--emit=dep-info=rust/.kernel.o.d", "--emit=obj=rust/kernel.o",
+		"rust/kernel/lib.rs",
+	})
+	if !ok {
+		t.Fatal("did not parse")
+	}
+	if rc.DepFile != "rust/.kernel.o.d" {
+		t.Errorf("DepFile = %q; fixdep would fail on the missing file", rc.DepFile)
+	}
+	if len(rc.Emits) != 1 {
+		t.Errorf("dep-info became an artifact: %+v", rc.Emits)
+	}
+}
+
+// The real command line kbuild records for a Rust driver, verbatim from
+// drivers/gpu/drm/.drm_panic_qr.o.cmd. It is here because reading the
+// argv grammar was not enough: `--remap-path-prefix FROM=TO` is a
+// SEPARATED two-argument flag, its value was taken for a second
+// positional, and the parser bailed. That bail is safe — the build runs
+// unaccelerated rather than wrong — but it is silent, so it cost a full
+// kernel run to notice.
+func TestParseRustcArgsRealKernelDriver(t *testing.T) {
+	args := []string{
+		"--edition=2021", "-Zbinary_dep_depinfo=y", "-Astable_features",
+		"-Dnon_ascii_idents", "-Wmissing_docs", "-Wclippy::all",
+		"-Aclippy::collapsible_if", "-Wrustdoc::missing_crate_level_docs",
+		"-Cpanic=abort", "-Cembed-bitcode=n", "-Ccodegen-units=1",
+		"-Csymbol-mangling-version=v0", "-Zfunction-sections=n",
+		"-Wclippy::float_arithmetic", "--target=./scripts/target.json",
+		"-Ctarget-feature=-sse,-sse2", "-Zcf-protection=branch",
+		"-Ctarget-cpu=x86-64", "-Ztune-cpu=generic", "-Ccode-model=kernel",
+		"-Zpatchable-function-entry=16,16", "-Copt-level=2", "-Cdebuginfo=2",
+		"--remap-path-prefix", "/nix/store/aaa-rust-lib-src=/",
+		"-Zallow-features=asm_const,asm_goto", "-Zcrate-attr=no_std",
+		"-Zcrate-attr=feature(asm_const,asm_goto)", "-Zunstable-options",
+		"--extern", "pin_init", "--extern", "kernel",
+		"--crate-type", "rlib", "-L", "./rust/",
+		"--crate-name", "drm_panic_qr", "--sysroot=/dev/null",
+		"--out-dir", "drivers/gpu/drm/",
+		"--emit=dep-info=drivers/gpu/drm/.drm_panic_qr.o.d",
+		"--emit=obj=drivers/gpu/drm/drm_panic_qr.o",
+		"../drivers/gpu/drm/drm_panic_qr.rs",
+	}
+	rc, _, ok := parseRustcArgs(args)
+	if !ok {
+		t.Fatal("did not parse the kernel's own rustc command line")
+	}
+	if rc.Source != "../drivers/gpu/drm/drm_panic_qr.rs" {
+		t.Errorf("Source = %q", rc.Source)
+	}
+	if len(rc.Emits) != 1 || rc.Emits[0].Path != "drivers/gpu/drm/drm_panic_qr.o" {
+		t.Errorf("Emits = %+v", rc.Emits)
+	}
+	if len(rc.Externs) != 2 {
+		t.Errorf("Externs = %+v", rc.Externs)
+	}
+	// A two-argument flag whose value was mistaken for the source is the
+	// exact shape of the bug this pins, so check the value did not leak
+	// back out as a flag of its own.
+	for _, f := range rc.Flags {
+		if f == "/nix/store/aaa-rust-lib-src=/" {
+			t.Errorf("--remap-path-prefix's value became a bare flag: %v", rc.Flags)
+		}
+	}
+}
+
+// The scan needs the caller's ORIGINAL command line, not the reduced
+// flag list the derivation gets. Stripped of `-L` and `--extern`, a
+// kernel crate compiled under `--sysroot=/dev/null` cannot resolve
+// `core`, and rustc then fails at the driver level — before it writes
+// any dep-info at all, so the scan has nothing to read and the crate
+// silently falls back to passthrough.
+func TestParseRustcArgsKeepsScanFlags(t *testing.T) {
+	rc, _, ok := parseRustcArgs([]string{
+		"--edition=2021", "--sysroot=/dev/null",
+		"-L", "./rust/", "--extern", "kernel",
+		"--emit=obj=x.o", "--out-dir", "d", "x.rs",
+	})
+	if !ok {
+		t.Fatal("did not parse")
+	}
+	want := []string{
+		"--edition=2021", "--sysroot=/dev/null",
+		"-L", "./rust/", "--extern", "kernel",
+		"--emit=obj=x.o", "--out-dir", "d",
+	}
+	if !reflect.DeepEqual(rc.ScanFlags, want) {
+		t.Errorf("ScanFlags = %q\nwant %q", rc.ScanFlags, want)
+	}
+	// The derivation's flags stay reduced — -L names the build tree and
+	// externs are resolved to explicit paths.
+	for _, f := range rc.Flags {
+		if f == "-L" || f == "./rust/" || f == "--extern" {
+			t.Errorf("build-tree flag %q leaked into the derivation flags: %v", f, rc.Flags)
+		}
+	}
+}

--- a/go/internal/shim/rustcenv.go
+++ b/go/internal/shim/rustcenv.go
@@ -1,0 +1,92 @@
+package shim
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// rustcEnvVars is the caller-declared list of environment variables a
+// crate reads at COMPILE time, via `env!()` or `std::env::var` in a
+// proc macro.
+//
+// Rust has no `-D` for this. A crate that wants a build-tree path
+// reaches for the environment instead, and the value is baked into the
+// compiled code:
+//
+//	include!(concat!(env!("OBJTREE"), "/rust/uapi/uapi_generated.rs"))
+//
+// That makes the variable part of the compile's input, so it has to
+// reach the derivation — an unset one is a hard rustc error, and a
+// wrong one silently compiles against the wrong file.
+//
+// It cannot be inferred. Nothing on the command line mentions it, and
+// carrying the whole environment would put the caller's PATH, TMPDIR
+// and build-tree paths into every drv hash, so no two machines would
+// ever share a cache entry.
+//
+// Same shape as NIXGG_PASSTHROUGH_PATHS, and for the same reason: the
+// rule is general, the list is not.
+const rustcEnvVar = "NIXGG_RUSTC_ENV"
+
+// rustcEnv returns the declared variables' values, with any path
+// inside the project rewritten to its position in the staged tree.
+//
+// The rewrite is what makes this work rather than merely pass. A value
+// like /build/linux-6.18.41 names a directory the sandbox does not
+// have; the same tree is mounted at srcStore, so `env!("OBJTREE")`
+// there has to name that instead. Values outside the project root are
+// carried verbatim — a version string is just a version string.
+func rustcEnv(projectRoot, srcStore string) map[string]string {
+	names := parseRustcEnvNames(os.Getenv(rustcEnvVar))
+	if len(names) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for _, n := range names {
+		v, ok := os.LookupEnv(n)
+		if !ok {
+			continue
+		}
+		out[n] = restagePath(v, projectRoot, srcStore)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func parseRustcEnvNames(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil
+	}
+	kept := out[:0]
+	for _, n := range out {
+		if strings.TrimSpace(n) != "" {
+			kept = append(kept, n)
+		}
+	}
+	return kept
+}
+
+// restagePath maps an absolute path under projectRoot onto srcStore,
+// and leaves everything else alone.
+func restagePath(v, projectRoot, srcStore string) string {
+	if !filepath.IsAbs(v) || projectRoot == "" || srcStore == "" {
+		return v
+	}
+	clean := filepath.Clean(v)
+	if clean == projectRoot {
+		return srcStore
+	}
+	rel, err := filepath.Rel(projectRoot, clean)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return v
+	}
+	return filepath.Join(srcStore, rel)
+}

--- a/go/internal/shim/rustcenv_test.go
+++ b/go/internal/shim/rustcenv_test.go
@@ -1,0 +1,64 @@
+package shim
+
+import (
+	"testing"
+)
+
+// The rewrite is the point, not the carry-through. A crate that does
+//
+//	include!(concat!(env!("OBJTREE"), "/rust/uapi/uapi_generated.rs"))
+//
+// gets a value naming the caller's build tree, which the sandbox does
+// not have. The same tree is mounted at the staged store path, so the
+// value has to name that instead — passed verbatim, rustc fails on a
+// missing file and points at the include, not at the variable.
+func TestRustcEnvRestagesProjectPaths(t *testing.T) {
+	const root = "/build/linux-6.18.41"
+	const staged = "/nix/store/aaa-rs-uapi.o"
+
+	for _, tc := range []struct{ name, in, want string }{
+		{"the project root itself", root, staged},
+		{"a path inside it", root + "/rust/uapi", staged + "/rust/uapi"},
+		{"a trailing slash", root + "/", staged},
+		{"a path outside it", "/nix/store/bbb-rustc", "/nix/store/bbb-rustc"},
+		{"a sibling with a shared prefix", "/build/linux-6.18.41-other", "/build/linux-6.18.41-other"},
+		{"not a path at all", "6.18.41", "6.18.41"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := restagePath(tc.in, root, staged); got != tc.want {
+				t.Errorf("restagePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Only declared variables travel. Carrying the whole environment would
+// put the caller's PATH and TMPDIR into every drv hash, so no two
+// machines would ever share a cache entry.
+func TestRustcEnvCarriesOnlyDeclaredVars(t *testing.T) {
+	t.Setenv("OBJTREE", "/build/tree")
+	t.Setenv("RUST_MODFILE", "drivers/foo.rs")
+	t.Setenv("TMPDIR", "/tmp/should-not-travel")
+
+	t.Setenv(rustcEnvVar, `["OBJTREE","MISSING_ON_PURPOSE"]`)
+	got := rustcEnv("/build/tree", "/nix/store/aaa-crate")
+
+	if got["OBJTREE"] != "/nix/store/aaa-crate" {
+		t.Errorf("OBJTREE = %q", got["OBJTREE"])
+	}
+	if _, ok := got["TMPDIR"]; ok {
+		t.Error("TMPDIR travelled; every drv hash would then depend on the caller's temp dir")
+	}
+	if _, ok := got["MISSING_ON_PURPOSE"]; ok {
+		t.Error("an unset variable was carried as empty rather than omitted")
+	}
+	if _, ok := got["RUST_MODFILE"]; ok {
+		t.Error("an undeclared variable travelled")
+	}
+
+	// Nothing declared is the normal case and must add nothing to the drv.
+	t.Setenv(rustcEnvVar, "")
+	if got := rustcEnv("/build/tree", "/nix/store/aaa-crate"); got != nil {
+		t.Errorf("undeclared env produced %v, want nil", got)
+	}
+}

--- a/go/internal/shim/scratch.go
+++ b/go/internal/shim/scratch.go
@@ -1,0 +1,49 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// The shims memoise expensive store-adds in files under the build root.
+// Where those live is load-bearing: `nixgg assemble` captures that root
+// and hands it to `nix store add --scan`, which records a reference for
+// every store path it finds — and a memo file's entire content IS a
+// store path. A memo directory at the build root therefore adds one
+// reference per memo to the captured tree's closure, which Nix then
+// bind-mounts into every derivation consuming that tree.
+//
+// assemble.skipNames already excludes ".nixgg" at any depth, so rooting
+// scratch there makes new caches excluded by construction. Adding each
+// new name to a denylist in another package is the alternative, and it
+// fails silently: an over-large closure is not an error until it hits a
+// kernel mount limit at build time.
+//
+// Not everything under the build root is scratch — dynDrvStdenv writes
+// files there for phase 2 to read back — so this is a positive
+// convention for scratch rather than a blanket exclusion.
+const scratchDirName = ".nixgg"
+
+// scratchDir returns a directory for shim scratch that assemble will not
+// capture, creating it if needed. Rooted at $NIX_BUILD_TOP so it lives
+// exactly as long as the build does; falls back to the system temp dir
+// outside a sandbox.
+//
+// sub names the kind of scratch ("shared", "tools"), keeping unrelated
+// caches from colliding in one flat directory.
+func scratchDir(sub string) (string, error) {
+	dir := filepath.Join(cacheRoot(), scratchDirName, sub)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// cacheRoot picks a directory that lives as long as the build does:
+// $NIX_BUILD_TOP inside a sandbox, the system temp dir otherwise.
+func cacheRoot() string {
+	if v := os.Getenv("NIX_BUILD_TOP"); v != "" {
+		return v
+	}
+	return os.TempDir()
+}

--- a/go/internal/shim/scratch_test.go
+++ b/go/internal/shim/scratch_test.go
@@ -1,0 +1,55 @@
+package shim
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Shim scratch must live under a directory assemble already excludes.
+//
+// A memo file's content IS a store path, so a cache at the build root
+// puts one reference per memo into the captured tree's closure, which
+// Nix then bind-mounts into every derivation consuming that tree. At
+// scale that is tens of thousands of extra references, and the build
+// dies with "bind mount ... failed: No space left on device" on a disk
+// that is nowhere near full.
+//
+// Nothing about that failure points at a memo cache, and adding each new
+// cache name to a denylist in another package is what allowed it: the
+// cache was written long after the denylist and nothing tied them
+// together. So assert the convention here, where the scratch is created.
+func TestScratchDirIsExcludedFromAssembly(t *testing.T) {
+	t.Setenv("NIX_BUILD_TOP", t.TempDir())
+
+	for _, sub := range []string{"shared", "tools"} {
+		dir, err := scratchDir(sub)
+		if err != nil {
+			t.Fatalf("scratchDir(%q): %v", sub, err)
+		}
+		// assemble.skipNames matches on a path COMPONENT at any depth,
+		// so the guarantee is that one component is ".nixgg".
+		var excluded bool
+		for _, part := range strings.Split(filepath.ToSlash(dir), "/") {
+			if part == scratchDirName {
+				excluded = true
+			}
+		}
+		if !excluded {
+			t.Errorf("scratchDir(%q) = %q, which has no %q component — "+
+				"assemble will capture it and every memo becomes a "+
+				"reference in the assembled tree's closure",
+				sub, dir, scratchDirName)
+		}
+	}
+}
+
+// The name has to stay in step with assemble.skipNames. They live in
+// different packages, so nothing but this test connects them.
+func TestScratchDirNameMatchesAssemblySkipList(t *testing.T) {
+	if scratchDirName != ".nixgg" {
+		t.Errorf("scratchDirName = %q; assemble.skipNames excludes \".nixgg\". "+
+			"Changing one without the other silently reintroduces the "+
+			"closure blowup.", scratchDirName)
+	}
+}

--- a/go/internal/shim/shared.go
+++ b/go/internal/shim/shared.go
@@ -1,0 +1,88 @@
+package shim
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tbereknyei/nixgg/internal/sandbox"
+	"github.com/tbereknyei/nixgg/internal/toolchain"
+)
+
+// sharedStagingEnabled reports whether staged trees should be symlink
+// farms into per-file store objects rather than hardlinked copies.
+//
+// Gated while the approach is being proven. The decisive unknown is
+// whether `nix store add --scan` records a symlink TARGET as a
+// reference: if it only scans file contents, the header objects never
+// become inputs of the staged tree, so they are not mounted in the
+// inner build sandbox and every compile fails on a missing header.
+func sharedStagingEnabled() bool {
+	return os.Getenv("NIXGG_SHARED_STAGE") == "1"
+}
+
+// storeShared puts one file in the store and returns its path,
+// memoised so a header included by thousands of translation units is
+// added once per build.
+//
+// The memo is a directory of one file per key rather than a single
+// index: shims run concurrently under `make -j`, and one-file-per-key
+// with an atomic rename needs no locking.
+//
+// Keyed on path+mtime+size rather than content. Hashing every header of
+// every TU would be millions of hashes; within a single build the
+// inputs do not change underneath us, and `nix store add` hashes the
+// content anyway to decide the store path — so identical content still
+// collapses to one object even when two different paths hold it.
+func storeShared(cfg *toolchain.Config, path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	st, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	key := fmt.Sprintf("%s|%d|%d", abs, st.ModTime().UnixNano(), st.Size())
+	sum := sha256.Sum256([]byte(key))
+	name := hex.EncodeToString(sum[:16])
+
+	// Under .nixgg/ so the assembly never captures it — see scratch.go.
+	dir, dirErr := scratchDir("shared")
+	cache := ""
+	if dirErr == nil {
+		cache = filepath.Join(dir, name)
+		if b, err := os.ReadFile(cache); err == nil {
+			if sp := strings.TrimSpace(string(b)); sp != "" {
+				return sp, nil
+			}
+		}
+	}
+
+	sp, err := sandbox.StoreAddScan(cfg, filepath.Base(abs), abs)
+	if err != nil {
+		return "", err
+	}
+	if cache != "" {
+		// os.CreateTemp, not a fixed cache+".tmp": every shim racing for
+		// the same header computes the SAME cache path, and os.WriteFile
+		// opens O_TRUNC. Two concurrent writers would share one temp file
+		// — B truncates while A is mid-write, then A renames the short
+		// result into place. A later reader passes the non-empty guard
+		// above and stages a symlink to a truncated store path. Same
+		// hazard, same fix as storeAddTool in objtool.go.
+		if tmp, err := os.CreateTemp(filepath.Dir(cache), ".shared-*"); err == nil {
+			_, werr := tmp.WriteString(sp)
+			cerr := tmp.Close()
+			if werr == nil && cerr == nil {
+				_ = os.Rename(tmp.Name(), cache) // atomic; losing a race is harmless
+			} else {
+				_ = os.Remove(tmp.Name())
+			}
+		}
+	}
+	return sp, nil
+}

--- a/go/internal/shim/storeinput.go
+++ b/go/internal/shim/storeinput.go
@@ -206,6 +206,30 @@ func classifyInputs(
 				Kind: "drv", Ref: c.Ref, Name: name,
 			})
 			expandMembers(l, expr.StoreBasename(c.Ref), &ci.ExtraLink, &ci.ExtraJSON, seenLink, seenJSON, archKeys)
+		case classify.Regular:
+			// A real file nixgg did not produce — a project may compile
+			// some objects with a tool the shims do not cover.
+			//
+			// Bailing is not a local decision: an unmodellable input makes
+			// THIS archive passthrough, hence a plain file, which makes its
+			// parent unmodellable in turn, all the way up. So store the
+			// file and depend on its content instead.
+			//
+			// Sandbox mode only. Native mode has no cascade to break, and a
+			// store round-trip there would change drv content for builds
+			// that work today.
+			if !sandbox.Enabled() {
+				logf("%s passthrough: can't model input %s (%s)", logPrefix, in, c.Reason())
+				return classifiedInputs{}, passthrough(), false
+			}
+			sp, err := storeAddLooseFile(cfg, in)
+			if err != nil {
+				logf("%s passthrough: store-add %s failed: %v", logPrefix, in, err)
+				return classifiedInputs{}, passthrough(), false
+			}
+			appendJSONDedup(&ci.JSON, seenJSON, expr.JSONDrvInput{
+				Kind: "src", Ref: filepath.Base(sp), Name: filepath.Base(in),
+			})
 		default:
 			logf("%s passthrough: can't model input %s (%s)", logPrefix, in, c.Reason())
 			return classifiedInputs{}, passthrough(), false
@@ -409,4 +433,31 @@ func multiTargetName(path string) string {
 		return ""
 	}
 	return os.Getenv("name") + "-" + strings.TrimSuffix(key, ".drv")
+}
+
+// storeAddLooseFile puts a single build-tree file into the store as a
+// DIRECTORY containing it.
+//
+// `nix store add <file>` would give a store path that IS the file, but
+// both serializers render an input's argv token as Ref+"/"+Name and
+// expect Ref to be a directory — the shape every drv output already
+// has. Staging into a one-file directory keeps that invariant instead
+// of special-casing the emitters, which are the byte-identity-critical
+// part of the codebase.
+func storeAddLooseFile(cfg *toolchain.Config, path string) (string, error) {
+	base := filepath.Base(path)
+	tmp, err := os.MkdirTemp(os.Getenv("NIX_BUILD_TOP"), "gg-loose-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmp)
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(tmp, base), src, 0o444); err != nil {
+		return "", err
+	}
+	return sandbox.StoreAddScan(cfg, base, tmp)
 }

--- a/go/internal/shim/storeinput.go
+++ b/go/internal/shim/storeinput.go
@@ -159,13 +159,31 @@ func classifyInputs(
 	seenLink := map[string]bool{}
 	seenJSON := map[string]bool{}
 	archKeys := map[string]bool{}
-	for _, in := range inputs {
+
+	// A worklist rather than a range, because expanding a FOREIGN thin
+	// archive — one nixgg did not produce, so it has no members sidecar
+	// and arrives as classify.Regular (see thinar.go) — appends its
+	// members back onto the list, and those can themselves be thin
+	// archives. Archives nixgg DID produce take the sidecar path
+	// instead, via expandMembers below; the two are disjoint.
+	//
+	// `expanded` guards ONLY the members synthesised here, so a nested
+	// archive reached twice, or a cycle, cannot loop. It deliberately
+	// does not cover the caller's own inputs: link order is significant
+	// and repeats are meaningful there.
+	pending := append([]string(nil), inputs...)
+	expanded := make(map[string]bool)
+	for len(pending) > 0 {
+		in := pending[0]
+		pending = pending[1:]
+
 		if batchpending.Is(in) {
 			if err := ResolvePendingMember(cfg, l, in); err != nil {
 				logf("%s passthrough: resolving deferred batch member %s: %v", logPrefix, in, err)
 				return classifiedInputs{}, passthrough(), false
 			}
 		}
+
 		c := classify.Target(in, altPrefix, l)
 		switch c.Kind {
 		case classify.Store:
@@ -221,6 +239,34 @@ func classifyInputs(
 			if !sandbox.Enabled() {
 				logf("%s passthrough: can't model input %s (%s)", logPrefix, in, c.Reason())
 				return classifiedInputs{}, passthrough(), false
+			}
+			// A thin archive is a list of PATHS, not bytes, so storing
+			// the file alone loses everything it points at — see
+			// thinar.go. Expand it and depend on the members instead.
+			if members, isThin, parsed := thinArchiveMembers(in); isThin {
+				if !parsed {
+					// Thin, but the member table would not parse. Storing
+					// it is the one thing we must not do: it holds paths,
+					// not bytes, so its members would vanish silently and
+					// surface as undefined references at the final link.
+					logf("%s passthrough: unparseable thin archive %s", logPrefix, in)
+					return classifiedInputs{}, passthrough(), false
+				}
+				logf("  %s: expanding thin archive %s (%d members)", logPrefix, in, len(members))
+				// Only expanded members are deduped, and only against
+				// other expanded members: a nested archive can be
+				// reached twice (a diamond) or cycle. The caller's own
+				// input list must keep every occurrence — `-lfoo … -lfoo`
+				// is the standard circular-archive idiom and dropping the
+				// repeat loses symbol resolution.
+				for _, m := range members {
+					if expanded[m] {
+						continue
+					}
+					expanded[m] = true
+					pending = append(pending, m)
+				}
+				continue
 			}
 			sp, err := storeAddLooseFile(cfg, in)
 			if err != nil {

--- a/go/internal/shim/storeinput.go
+++ b/go/internal/shim/storeinput.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tbereknyei/nixgg/internal/classify"
 	"github.com/tbereknyei/nixgg/internal/expr"
 	"github.com/tbereknyei/nixgg/internal/members"
+	"github.com/tbereknyei/nixgg/internal/mode"
 	"github.com/tbereknyei/nixgg/internal/paths"
 	"github.com/tbereknyei/nixgg/internal/sandbox"
 	"github.com/tbereknyei/nixgg/internal/toolchain"
@@ -506,4 +507,17 @@ func storeAddLooseFile(cfg *toolchain.Config, path string) (string, error) {
 		return "", err
 	}
 	return sandbox.StoreAddScan(cfg, base, tmp)
+}
+
+// carvedOut reports whether a subtree is excluded from modelling.
+//
+// A declared subtree means "nixgg models nothing here", so every shim
+// that produces an artifact has to honour it directly rather than
+// inherit it from its inputs. Inheriting only worked while unmodellable
+// inputs made the whole subtree bail together; once those are
+// store-added instead, a shim can model an artifact inside a subtree
+// whose siblings were passed through, and the two halves no longer
+// agree.
+func carvedOut(path string) bool {
+	return mode.For(path) == mode.Passthrough
 }

--- a/go/internal/shim/thinar.go
+++ b/go/internal/shim/thinar.go
@@ -1,0 +1,138 @@
+package shim
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// A GNU "thin" archive (`ar` with the T modifier) stores PATHS TO its
+// members, not their bytes, and build systems nest them.
+//
+// That is fine while every member path stays resolvable: a modelled
+// sub-archive records its members as absolute store paths, which resolve
+// anywhere. It breaks for a sub-archive nixgg did NOT model, because
+// classifyInputs stores that file ALONE — its siblings are not beside
+// it, so when the parent `ar` flattens the nested archive every member
+// resolves to nothing and is dropped. Silently: ar reports no error, the
+// archive is just smaller, and the damage only surfaces at the final
+// link as undefined references.
+//
+// So a thin archive cannot be treated as an opaque file. Expand it into
+// its members and depend on those — see classifyInputs.
+const thinMagic = "!<thin>\n"
+
+// arHeaderSize is the fixed size of an ar member header.
+const arHeaderSize = 60
+
+// thinArchiveMembers parses a GNU thin archive and returns its member
+// paths, resolved against the archive's own directory (thin archives
+// record relative paths that way).
+//
+// Three outcomes, and callers must tell them apart:
+//
+//   - isThin=false           not a thin archive (a normal archive, or
+//     not an archive at all). Safe to store whole: it carries bytes.
+//   - isThin=true, ok=false  the magic says thin, but the member table
+//     is malformed or truncated. Storing this file is the WORST
+//     outcome — it is a path list, so its members silently vanish and
+//     the damage surfaces at the final link. Callers must bail to
+//     passthrough instead.
+//   - isThin=true, ok=true   members parsed; depend on those.
+//
+// Parsed here rather than shelled out to `ar t`: ar wants to resolve the
+// members it lists, so on exactly the broken archives this exists to fix
+// it fails with a message naming the ARCHIVE rather than the member,
+// which is worse than useless as a diagnostic.
+func thinArchiveMembers(path string) (members []string, isThin bool, ok bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false, false
+	}
+	defer f.Close()
+
+	// ReadFull, not Read: a short read is not an error, so a file
+	// shorter than the magic would compare unequal and be reported as
+	// "not thin" — the one answer that gets it stored whole.
+	magic := make([]byte, len(thinMagic))
+	if _, err := io.ReadFull(f, magic); err != nil || string(magic) != thinMagic {
+		return nil, false, false
+	}
+
+	// Past here the file IS thin, so every failure below reports
+	// isThin=true and lets the caller bail rather than store it.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, true, false
+	}
+	body = body[len(thinMagic):]
+
+	dir := filepath.Dir(path)
+	var longNames []byte
+
+	for len(body) >= arHeaderSize {
+		hdr := body[:arHeaderSize]
+		name := strings.TrimRight(string(hdr[0:16]), " ")
+		size, err := strconv.Atoi(strings.TrimSpace(string(hdr[48:58])))
+		if err != nil || size < 0 {
+			break
+		}
+		body = body[arHeaderSize:]
+
+		switch {
+		case name == "//":
+			// The long-name table: the only member of a thin archive
+			// that actually carries data, alongside the symbol index.
+			// Guard the PADDED length: ar pads members to an even
+			// boundary, so an odd size that exactly fills body means the
+			// pad byte is missing and the archive is truncated. Guarding
+			// only `size` would slice past the end and panic.
+			if size+size%2 > len(body) {
+				return nil, true, false
+			}
+			longNames = body[:size]
+			body = body[size+size%2:]
+			continue
+		case name == "/" || name == "/SYM64/":
+			// Symbol index, also carries data. Same padded-length guard.
+			if size+size%2 > len(body) {
+				return nil, true, false
+			}
+			body = body[size+size%2:]
+			continue
+		}
+
+		// Every other member of a thin archive is a reference: the
+		// header records the size the file HAS, but no data follows it.
+		var member string
+		if strings.HasPrefix(name, "/") {
+			off, err := strconv.Atoi(name[1:])
+			if err != nil || off < 0 || off >= len(longNames) {
+				continue
+			}
+			member = readLongName(longNames[off:])
+		} else {
+			member = strings.TrimSuffix(name, "/")
+		}
+		if member == "" {
+			continue
+		}
+		if !filepath.IsAbs(member) {
+			member = filepath.Join(dir, member)
+		}
+		members = append(members, member)
+	}
+	return members, true, true
+}
+
+// readLongName pulls one entry out of the "//" table, which terminates
+// names with "/\n" (or just "\n" from some producers).
+func readLongName(b []byte) string {
+	if i := bytes.IndexAny(b, "\n"); i >= 0 {
+		b = b[:i]
+	}
+	return strings.TrimSuffix(string(b), "/")
+}

--- a/go/internal/shim/thinar_test.go
+++ b/go/internal/shim/thinar_test.go
@@ -1,0 +1,176 @@
+package shim
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Built with the real `ar`, not a hand-rolled fixture: the whole point
+// is to parse what GNU ar actually emits, including its long-name table.
+func buildThinArchive(t *testing.T, dir string, members ...string) string {
+	t.Helper()
+	arBin := arPath(t)
+	var rels []string
+	for _, m := range members {
+		p := filepath.Join(dir, m)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("\x7fELF fake "+m), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rels = append(rels, m)
+	}
+	archive := filepath.Join(dir, "built-in.a")
+	// The modifier set build systems use for aggregate archives.
+	cmd := exec.Command(arBin, append([]string{"cDPrST", "built-in.a"}, rels...)...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ar failed: %v\n%s", err, out)
+	}
+	return archive
+}
+
+// A thin archive's members must be recoverable, because
+// storing the archive file alone loses them and the parent `ar` then
+// drops them without error. Long member paths exercise the "//"
+// long-name table, which is where a naive parser breaks.
+func TestThinArchiveMembers(t *testing.T) {
+	dir := t.TempDir()
+	archive := buildThinArchive(t, dir,
+		"init.o",
+		"rmpiggy.o",
+		"some/deeply/nested/path/that/needs/the/long/name/table/object.o",
+	)
+
+	members, isThin, ok := thinArchiveMembers(archive)
+	if !isThin {
+		t.Fatal("real `ar cDPrST` output was not recognised as thin")
+	}
+	if !ok {
+		t.Fatal("real `ar cDPrST` output was not recognised as a thin archive")
+	}
+	if len(members) != 3 {
+		t.Fatalf("got %d members, want 3: %q", len(members), members)
+	}
+	// Paths must be resolved against the archive's directory, or the
+	// caller cannot store-add them.
+	for _, m := range members {
+		if !filepath.IsAbs(m) {
+			t.Errorf("member %q is not absolute; caller cannot open it", m)
+		}
+		if _, err := os.Stat(m); err != nil {
+			t.Errorf("member %q does not resolve: %v", m, err)
+		}
+	}
+}
+
+// A normal (fat) archive carries its members' bytes, so it needs no
+// expansion — and must not be mistaken for a thin one.
+func TestThinArchiveMembersRejectsFatArchive(t *testing.T) {
+	arBin := arPath(t)
+	dir := t.TempDir()
+	obj := filepath.Join(dir, "a.o")
+	if err := os.WriteFile(obj, []byte("\x7fELF fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(dir, "fat.a")
+	cmd := exec.Command(arBin, "crs", "fat.a", "a.o")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ar failed: %v\n%s", err, out)
+	}
+	if _, isThin, _ := thinArchiveMembers(archive); isThin {
+		t.Error("a fat archive was reported as thin; expanding it would be wrong")
+	}
+}
+
+func TestThinArchiveMembersRejectsNonArchives(t *testing.T) {
+	dir := t.TempDir()
+	obj := filepath.Join(dir, "plain.o")
+	if err := os.WriteFile(obj, []byte("\x7fELF not an archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{obj, filepath.Join(dir, "absent.a"), dir} {
+		if _, isThin, _ := thinArchiveMembers(p); isThin {
+			t.Errorf("%s was reported as a thin archive", p)
+		}
+	}
+}
+
+// Build systems emit empty aggregate archives, and GNU ar writes those
+// as a plain "!<arch>" — it only
+// switches to "!<thin>" once there is a member to reference. Verified
+// directly: `ar cDPrST empty.a` produces exactly 8 bytes of "!<arch>".
+//
+// So an empty archive is correctly NOT reported as thin, and falls
+// through to being store-added whole. That is harmless: there are no
+// member paths to lose, which is the only thing expansion protects
+// against.
+func TestThinArchiveMembersEmptyArchiveIsNotThin(t *testing.T) {
+	dir := t.TempDir()
+	archive := buildThinArchive(t, dir)
+	if _, isThin, _ := thinArchiveMembers(archive); isThin {
+		t.Error("empty archive reported as thin; ar writes !<arch> for these")
+	}
+}
+
+// arPath finds a real `ar`. PATH first, then the binutils in the store —
+// without this the thin-archive tests silently SKIP in environments
+// where ar is not on PATH, which is exactly where a parser regression
+// would go unnoticed.
+func arPath(t *testing.T) string {
+	t.Helper()
+	if p, err := exec.LookPath("ar"); err == nil {
+		return p
+	}
+	for _, pat := range []string{
+		"/nix/store/*binutils-*/bin/ar",
+		"/nix/store/*gcc-wrapper-*/bin/ar",
+	} {
+		if m, _ := filepath.Glob(pat); len(m) > 0 {
+			return m[0]
+		}
+	}
+	t.Skip("no ar available anywhere")
+	return ""
+}
+
+// A truncated "//" long-name table must be rejected, not panic.
+//
+// ar pads every member to an even boundary, so the parser advances by
+// size+size%2. If an odd-sized member runs exactly to the end of the
+// file its pad byte is missing, and a guard that checks only `size`
+// lets the advance slice past the end — panicking inside the shim
+// mid-build instead of falling back to the real ar.
+//
+// Hand-rolled rather than built with ar, because ar will not emit a
+// truncated archive.
+func TestThinArchiveMembersTruncatedLongNameTable(t *testing.T) {
+	hdr := make([]byte, arHeaderSize)
+	for i := range hdr {
+		hdr[i] = ' '
+	}
+	copy(hdr[0:], "//")
+	copy(hdr[48:], "3")   // size: odd
+	copy(hdr[58:], "`\n") // fmag
+
+	// Exactly 3 bytes of table and no pad byte: size == len(body), odd.
+	data := append([]byte(thinMagic), hdr...)
+	data = append(data, 'a', 'b', 'c')
+
+	path := filepath.Join(t.TempDir(), "truncated.a")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	members, isThin, ok := thinArchiveMembers(path)
+	if !isThin {
+		t.Fatal("truncated thin archive reported as NOT thin; it would be stored whole, silently losing every member")
+	}
+	if ok {
+		t.Errorf("truncated archive parsed as valid, members=%v", members)
+	}
+}

--- a/go/internal/stage/shared_scan_test.go
+++ b/go/internal/stage/shared_scan_test.go
@@ -1,0 +1,143 @@
+package stage
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tbereknyei/nixgg/internal/paths"
+)
+
+// Shared staging replaces every staged file with a symlink into a
+// content-addressed store object, so a farm's hash depends on its headers
+// only INDIRECTLY — through the target path strings in the NAR. Copying got
+// content-tracking for free because the bytes were in the NAR; symlinking
+// gets it only because the target path is itself derived from content. If
+// that ever broke, a header edit would leave the farm's hash unchanged and
+// every dependent TU would reuse a stale compile — silently, and with no
+// build failure to point at it.
+//
+// TestSourcesShared covers the tree SHAPE with a fake store. This covers
+// the hashing, which needs a real one.
+//
+// The other half of the scheme — that `nix store add --scan` records
+// symlink targets as REFERENCES — cannot be tested here: --scan only works
+// inside a recursive-nix derivation builder. It is pinned end-to-end by
+// tests/shared-closure.sh, which also documents why that half is less
+// fragile than it looks (Nix mounts only an input's closure, so a missing
+// reference fails the compile outright rather than silently).
+func TestSourcesSharedHashTracksContent(t *testing.T) {
+	nixBin := requireNix(t)
+	isolatedStore(t)
+
+	farmFor := func(content string) string {
+		root := t.TempDir()
+		src := filepath.Join(root, "src")
+		if err := os.MkdirAll(src, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(src, "hdr.h"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		store := func(abs string) (string, error) {
+			return runNix(t, nixBin, "store", "add", "-n", filepath.Base(abs), abs)
+		}
+		l := paths.Layout{Srcs: filepath.Join(root, "srcs")}
+		res, err := SourcesShared(l, "tu0", []Entry{
+			{Abs: filepath.Join(src, "hdr.h"), Rel: "hdr.h"},
+		}, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Readlink(filepath.Join(res, "hdr.h")); err != nil {
+			t.Fatalf("staged hdr.h is not a symlink: %v", err)
+		}
+		// Plain `store add` (no --scan): references are metadata and do not
+		// participate in this path computation, so the hashing property is
+		// observable outside a builder even though --scan is not.
+		farm, err := runNix(t, nixBin, "store", "add", "-n", "farm", res)
+		if err != nil {
+			t.Fatalf("store-add farm: %v", err)
+		}
+		return farm
+	}
+
+	a1 := farmFor("#define V 1\n")
+	a2 := farmFor("#define V 1\n")
+	b := farmFor("#define V 2\n")
+
+	if a1 != a2 {
+		t.Errorf("identical content produced different farms:\n  %s\n  %s\n"+
+			"Staged trees must be reproducible or nothing caches across machines.", a1, a2)
+	}
+	if a1 == b {
+		t.Errorf("changed header content did NOT change the farm hash (%s).\n"+
+			"Dependents would reuse a stale compile.", a1)
+	}
+}
+
+func runNix(t *testing.T, nixBin string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(nixBin, append([]string{"--offline"}, args...)...)
+	cmd.Env = os.Environ()
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errWith(err, stderr.String())
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func errWith(err error, stderr string) error {
+	if stderr == "" {
+		return err
+	}
+	return &nixErr{err: err, stderr: stderr}
+}
+
+type nixErr struct {
+	err    error
+	stderr string
+}
+
+func (e *nixErr) Error() string { return e.err.Error() + "\n" + e.stderr }
+
+// requireNix locates a nix binary, preferring the repo's patched build,
+// and skips when none is available so `go test ./...` still passes on a
+// machine without it.
+func requireNix(t *testing.T) string {
+	t.Helper()
+	if p, err := filepath.Abs("../../../.patched-nix/bin/nix"); err == nil {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	p, err := exec.LookPath("nix")
+	if err != nil {
+		t.Skip("no nix binary available; skipping store-backed test")
+	}
+	return p
+}
+
+// isolatedStore points nix at a throwaway store root so the test never
+// writes to the developer's real store or needs a daemon.
+func isolatedStore(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	// Store paths are read-only, so t.TempDir's own cleanup cannot remove
+	// them. Cleanups run LIFO, so this one restores write permission just
+	// before that removal.
+	t.Cleanup(func() {
+		filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+			if err == nil {
+				os.Chmod(p, 0o755)
+			}
+			return nil
+		})
+	})
+	t.Setenv("NIX_REMOTE", "local?root="+root)
+	t.Setenv("NIX_CONFIG", "experimental-features = nix-command")
+}

--- a/go/internal/stage/stage.go
+++ b/go/internal/stage/stage.go
@@ -270,3 +270,50 @@ func TUID(absOutput string) string {
 	h := sha256.Sum256([]byte(absOutput))
 	return slug + "-" + hex.EncodeToString(h[:6])
 }
+
+// SourcesShared stages entries as SYMLINKS into per-file store objects
+// rather than hardlinked copies.
+//
+// The staged tree keeps its exact shape — same relative paths, so
+// `#include "../foo.h"` and the caller's -I flags resolve unchanged —
+// but its bytes collapse from the full header closure to one symlink
+// entry each. A TU staging ~190 headers becomes ~190
+// symlinks / a few KB, and the header content is stored once no matter
+// how many TUs include it.
+//
+// That matters because the closure is overwhelmingly shared: across 60
+// sampled translation units the same headers recurred roughly 17x, and
+// a per-TU copy pays that duplication in full every time.
+//
+// store maps an absolute path to the store object holding its content;
+// the caller supplies it so this package stays free of nix plumbing.
+// Returns the absolute path to .nixgg/srcs/<tu-id>/, like Sources.
+func SourcesShared(l paths.Layout, tuID string, entries []Entry, store func(abs string) (string, error)) (string, error) {
+	dir := filepath.Join(l.Srcs, tuID)
+	if err := os.MkdirAll(l.Srcs, 0o755); err != nil {
+		return "", err
+	}
+	// No reuse check: the symlink targets are content-addressed, so a
+	// changed header yields a different target and the cheap thing is to
+	// rebuild the (tiny) farm.
+	if err := os.RemoveAll(dir); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		sp, err := store(e.Abs)
+		if err != nil {
+			return "", fmt.Errorf("share %s: %w", e.Abs, err)
+		}
+		dst := filepath.Join(dir, e.Rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return "", err
+		}
+		if err := os.Symlink(sp, dst); err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}

--- a/go/internal/stage/stage_test.go
+++ b/go/internal/stage/stage_test.go
@@ -3,6 +3,7 @@ package stage
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tbereknyei/nixgg/internal/paths"
@@ -114,4 +115,58 @@ func testLayout(t *testing.T) paths.Layout {
 	t.Helper()
 	base := t.TempDir()
 	return paths.Layout{Srcs: filepath.Join(base, "srcs")}
+}
+
+// SourcesShared must reproduce the tree's SHAPE exactly — relative
+// paths are what make `#include "../foo.h"` and the caller's -I flags
+// resolve — while replacing contents with symlinks into shared store
+// objects.
+func TestSourcesShared(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"a.c", "sub/dup.h", "other.h"} {
+		if err := os.WriteFile(filepath.Join(src, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	l := paths.Layout{Srcs: filepath.Join(root, "srcs")}
+	entries := []Entry{
+		{Abs: filepath.Join(src, "a.c"), Rel: "a.c"},
+		{Abs: filepath.Join(src, "sub/dup.h"), Rel: "sub/dup.h"},
+		{Abs: filepath.Join(src, "other.h"), Rel: "other.h"},
+	}
+
+	// Stand-in for the store: identical content collapses to one object,
+	// which is the property the real implementation gets from
+	// content-addressing.
+	calls := 0
+	store := func(abs string) (string, error) {
+		calls++
+		return "/nix/store/deadbeef-" + filepath.Base(abs), nil
+	}
+
+	res, err := SourcesShared(l, "tu-1", entries, store)
+	if err != nil {
+		t.Fatalf("SourcesShared: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("store called %d times, want 3", calls)
+	}
+	for _, e := range entries {
+		p := filepath.Join(res, e.Rel)
+		fi, err := os.Lstat(p)
+		if err != nil {
+			t.Fatalf("%s missing: %v", e.Rel, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s is not a symlink — the whole point is to stop copying", e.Rel)
+		}
+		tgt, _ := os.Readlink(p)
+		if !strings.HasPrefix(tgt, "/nix/store/") {
+			t.Errorf("%s -> %q, want a store path", e.Rel, tgt)
+		}
+	}
 }

--- a/go/main.go
+++ b/go/main.go
@@ -57,6 +57,8 @@ func run() error {
 		// it was written flag-family-agnostic from the start (bare -T,
 		// bare --start-group/--end-group).
 		return shim.Link(tool, args, cfg, l)
+	case dispatch.ToolObjtool:
+		return shim.Objtool(args, cfg, l)
 	case dispatch.ToolRanlib:
 		// ranlib on our thunk/store outputs would need to open+modify a
 		// file we don't own. Real ranlib on a real .a would be

--- a/go/main.go
+++ b/go/main.go
@@ -50,13 +50,18 @@ func run() error {
 	case dispatch.ToolAR:
 		return shim.Archive(args, cfg, l)
 	case dispatch.ToolLD:
-		// Raw `ld` (Kbuild's cmd_ld: `$(LD) $(ld_flags) $(real-prereqs)
-		// -o $@`) is always link-shaped — there's no compile mode to
-		// dispatch on the way cc/g++ have. Link's own parser already
-		// handles ld's bare (non `-Wl,`-wrapped) flag spellings, since
-		// it was written flag-family-agnostic from the start (bare -T,
-		// bare --start-group/--end-group).
-		return shim.Link(tool, args, cfg, l)
+		// `ld -r` (partial link: several objects in, one object out) has
+		// its own model — see shim.LD. A kernel emits ~2,000 of them,
+		// and they are not link-shaped: the output is an object that
+		// later archives and links consume.
+		//
+		// Everything else IS link-shaped (Kbuild's cmd_ld: `$(LD)
+		// $(ld_flags) $(real-prereqs) -o $@`), and shim.LD hands those
+		// to Link, whose parser already handles ld's bare (non
+		// `-Wl,`-wrapped) flag spellings — it was written
+		// flag-family-agnostic from the start (bare -T, bare
+		// --start-group/--end-group).
+		return shim.LD(args, cfg, l)
 	case dispatch.ToolObjtool:
 		return shim.Objtool(args, cfg, l)
 	case dispatch.ToolRanlib:

--- a/go/main.go
+++ b/go/main.go
@@ -42,9 +42,15 @@ func run() error {
 		return err
 	}
 
-	// Expand @rspfiles once at the top so every downstream parser sees
-	// the flattened form.
-	args := dispatch.ExpandRspfiles(os.Args[1:])
+	// Expand @argfiles once at the top so every downstream parser sees
+	// the flattened form. rustc's file format differs from the compiler
+	// drivers' — see ExpandRustArgfiles.
+	var args []string
+	if tool == dispatch.ToolRustc {
+		args = dispatch.ExpandRustArgfiles(os.Args[1:])
+	} else {
+		args = dispatch.ExpandRspfiles(os.Args[1:])
+	}
 
 	switch tool {
 	case dispatch.ToolAR:
@@ -66,6 +72,8 @@ func run() error {
 		return shim.Objtool(args, cfg, l)
 	case dispatch.ToolObjcopy:
 		return shim.Objcopy(args, cfg, l)
+	case dispatch.ToolRustc:
+		return shim.Rustc(args, cfg, l)
 	case dispatch.ToolRanlib:
 		// ranlib on our thunk/store outputs would need to open+modify a
 		// file we don't own. Real ranlib on a real .a would be

--- a/go/main.go
+++ b/go/main.go
@@ -64,6 +64,8 @@ func run() error {
 		return shim.LD(args, cfg, l)
 	case dispatch.ToolObjtool:
 		return shim.Objtool(args, cfg, l)
+	case dispatch.ToolObjcopy:
+		return shim.Objcopy(args, cfg, l)
 	case dispatch.ToolRanlib:
 		// ranlib on our thunk/store outputs would need to open+modify a
 		// file we don't own. Real ranlib on a real .a would be

--- a/nix/dynDrvShared.nix
+++ b/nix/dynDrvShared.nix
@@ -62,12 +62,15 @@
 
   # Records $PWD's offset relative to $NIX_BUILD_TOP (phase 2 needs to
   # cd back there — cmake's `mkdir build && cd build` means $PWD here
-  # isn't $NIX_BUILD_TOP), then walks $NIX_BUILD_TOP for every drvref
-  # stub the shims left, builds one assembly drv that restores the tree
-  # and resolves each stub, and submits it as this derivation's "out".
+  # isn't $NIX_BUILD_TOP) and phase 1's exported environment (phase 2
+  # replays it gap-filling; see splitStdenv's ggRestoreEnv), then
+  # walks $NIX_BUILD_TOP for every drvref stub the shims left, builds
+  # one assembly drv that restores the tree and resolves each stub, and
+  # submits it as this derivation's "out".
   # See go/internal/cli/assemble.go / go/internal/assemble/.
   submitBuildTreeScript = drvName: ''
     realpath --relative-to="$NIX_BUILD_TOP" "$PWD" > "$NIX_BUILD_TOP/.gg-cwd"
+    export -p > "$NIX_BUILD_TOP/.gg-env"
     ${nixgg}/bin/nixgg assemble "$NIX_BUILD_TOP" "${drvName}"
   '';
 

--- a/nix/dynDrvShared.nix
+++ b/nix/dynDrvShared.nix
@@ -10,7 +10,8 @@
 #
 # Every binding here closes over exactly the params splitStdenv.nix's
 # build stage needs (lib, nixgg, patchedNix, bash, coreutils, gcc,
-# gnumake, system) — its configure-only stage needs none of these.
+# gnumake, system), plus the optional sharedStaging flag — its
+# configure-only stage needs none of these.
 {
   lib,
   patchedNix,
@@ -19,6 +20,11 @@
   coreutils,
   gcc,
   gnumake,
+  # Stage each TU as a symlink farm into per-file store objects rather
+  # than copying (internal/stage's SourcesShared). Off by default so
+  # dynDrvConfigureCacheStdenv, which does not pass it, emits exactly
+  # the environment it did before this parameter existed.
+  sharedStaging ? false,
   system,
 }:
 
@@ -50,6 +56,7 @@
     export NIXGG_STORE="auto"
     export NIXGG_SYSTEM="${system}"
     export NIXGG_SANDBOX_TARGET="/nonexistent/nixgg-phase1-no-per-artifact-submit"
+    ${lib.optionalString sharedStaging "export NIXGG_SHARED_STAGE=1"}
     export NIXGG_KNOWN_STORE_PATHS=${lib.escapeShellArg knownStorePathsJSON}
     # Raw worker-protocol client for the sandbox's own daemon socket
     # (internal/rpc) instead of per-call fork+exec — see
@@ -67,6 +74,14 @@
   # walks $NIX_BUILD_TOP for every drvref stub the shims left, builds
   # one assembly drv that restores the tree and resolves each stub, and
   # submits it as this derivation's "out".
+  #
+  # The environment dump earns its keep because splitting one
+  # mkDerivation across two derivations splits the SHELL too, and
+  # packages routinely export a variable in one phase and read it in a
+  # later one: linux-config's configurePhase does `export
+  # buildRoot=...` and its installPhase is `mv $buildRoot/.config
+  # $out`, which in phase 2 became `mv /.config` — "cannot stat
+  # '/.config'".
   # See go/internal/cli/assemble.go / go/internal/assemble/.
   submitBuildTreeScript = drvName: ''
     realpath --relative-to="$NIX_BUILD_TOP" "$PWD" > "$NIX_BUILD_TOP/.gg-cwd"

--- a/nix/dynDrvShared.nix
+++ b/nix/dynDrvShared.nix
@@ -10,8 +10,8 @@
 #
 # Every binding here closes over exactly the params splitStdenv.nix's
 # build stage needs (lib, nixgg, patchedNix, bash, coreutils, gcc,
-# gnumake, system), plus the optional sharedStaging flag — its
-# configure-only stage needs none of these.
+# gnumake, system), plus two optional flags (passthroughPaths,
+# sharedStaging) — its configure-only stage needs none of these.
 {
   lib,
   patchedNix,
@@ -20,6 +20,11 @@
   coreutils,
   gcc,
   gnumake,
+  # Subtrees the caller has declared unmodellable; the shims pass work
+  # under them straight through (internal/mode). Empty by default so
+  # dynDrvConfigureCacheStdenv, which does not pass it, emits exactly
+  # the environment it did before this parameter existed.
+  passthroughPaths ? [ ],
   # Stage each TU as a symlink farm into per-file store objects rather
   # than copying (internal/stage's SourcesShared). Off by default so
   # dynDrvConfigureCacheStdenv, which does not pass it, emits exactly
@@ -57,6 +62,7 @@
     export NIXGG_SYSTEM="${system}"
     export NIXGG_SANDBOX_TARGET="/nonexistent/nixgg-phase1-no-per-artifact-submit"
     ${lib.optionalString sharedStaging "export NIXGG_SHARED_STAGE=1"}
+    export NIXGG_PASSTHROUGH_PATHS=${lib.escapeShellArg (builtins.toJSON passthroughPaths)}
     export NIXGG_KNOWN_STORE_PATHS=${lib.escapeShellArg knownStorePathsJSON}
     # Raw worker-protocol client for the sandbox's own daemon socket
     # (internal/rpc) instead of per-call fork+exec — see

--- a/nix/mkNixggBuild.nix
+++ b/nix/mkNixggBuild.nix
@@ -278,6 +278,11 @@ let
     export NIX_CFLAGS_COMPILE NIX_LDFLAGS
     export NIXGG_KNOWN_STORE_PATHS=${lib.escapeShellArg knownStorePathsJSON}
     export NIXGG_BATCH_GROUPS=${lib.escapeShellArg batchGroupsJSON}
+    # Must match the sandbox-side attr below. mode.Passthrough reads this
+    # in BOTH modes, so a native replay that lacks it models TUs the
+    # sandbox passed through — different drv sets, and drv-equivalence
+    # fails for any package that sets passthroughPaths.
+    export NIXGG_PASSTHROUGH_PATHS=${lib.escapeShellArg (builtins.toJSON passthroughPaths)}
   '';
 
   drv = stdenv.mkDerivation (

--- a/nix/mkNixggBuild.nix
+++ b/nix/mkNixggBuild.nix
@@ -105,8 +105,12 @@
   #   ];
   batchGroups ? [ ],
   # Stage each TU as a farm of symlinks into per-file store objects.
-  # Sandbox mode only, off by default — see dynDrvStdenv.sharedStaging.
+  # Sandbox mode only, off by default — see splitStdenv.sharedStaging.
   sharedStaging ? false,
+
+  # Subtrees whose build reads object bytes inline, or expects a compile
+  # to fail — see splitStdenv.passthroughPaths. Empty for most projects.
+  passthroughPaths ? [ ],
 }:
 
 let
@@ -339,6 +343,7 @@ let
       NIXGG_RPC            = "1";
     }
     // lib.optionalAttrs sharedStaging { NIXGG_SHARED_STAGE = "1"; }
+    // { NIXGG_PASSTHROUGH_PATHS = builtins.toJSON passthroughPaths; }
     // {
 
       # See scrubWrapperEnv above for what this does and why. Two points

--- a/nix/mkNixggBuild.nix
+++ b/nix/mkNixggBuild.nix
@@ -104,6 +104,9 @@
   #     { name = "vendor"; patterns = [ "deps/**/*.c" ]; }
   #   ];
   batchGroups ? [ ],
+  # Stage each TU as a farm of symlinks into per-file store objects.
+  # Sandbox mode only, off by default — see dynDrvStdenv.sharedStaging.
+  sharedStaging ? false,
 }:
 
 let
@@ -334,6 +337,10 @@ let
       # llvm). NIXGG_RPC=0 is the escape hatch back to the CLI
       # fallback if something unforeseen turns up.
       NIXGG_RPC            = "1";
+    }
+    // lib.optionalAttrs sharedStaging { NIXGG_SHARED_STAGE = "1"; }
+    // {
+
       # See scrubWrapperEnv above for what this does and why. Two points
       # specific to the sandbox side: the shims/ dir goes ahead of the
       # toolchain stdenv already put on PATH so cc/c++/ar dispatch through

--- a/nix/splitStdenv.nix
+++ b/nix/splitStdenv.nix
@@ -146,6 +146,21 @@ stdenv0.override (
         drvName = if probeArgs ? name then probeArgs.name else "${probeArgs.pname}-${probeArgs.version}";
         outerName = "gg-build-${drvName}";
 
+        # Honour what the package asked for: phases written against
+        # structuredAttrs use bash array syntax, which does not exist
+        # when it is off. Default matches make-derivation.nix.
+        structuredAttrs = probeArgs.__structuredAttrs or (config.structuredAttrsByDefault or false);
+
+        # builder-rpc-v0 wants $out unset; /nonexistent keeps stdenv's
+        # _assignFirst happy while making a real write fail loudly.
+        # Under structuredAttrs only `env` reaches the derivation as
+        # environment variables, so the placeholder goes there.
+        nonexistentOut =
+          if structuredAttrs then
+            { env = (probeArgs.env or { }) // { out = "/nonexistent"; }; }
+          else
+            { out = "/nonexistent"; };
+
         # Store paths the shim's storedeps matcher needs to recognize in
         # -I/-L flags — same computation as mkNixggBuild.nix's
         # knownStorePathInputs. Only forced (and thus only costs
@@ -335,7 +350,6 @@ stdenv0.override (
                     # suffix). The final stage keeps the package's real
                     # `outputs`.
                     outputs = [ "out" ];
-                    out = "/nonexistent";
                     # make-derivation.nix computes `outputs' = outputs ++
                     # optional separateDebugInfo' "debug"` at its OWN
                     # layer, downstream of this override, so `outputs =
@@ -366,7 +380,11 @@ stdenv0.override (
                     }) extraOutputs
                   )
                   // {
-                    __structuredAttrs = false;
+                    # Honoured, not forced: the package's phases may be
+                    # written against structuredAttrs. The `out`
+                    # placeholder moves into `env` to match — see
+                    # nonexistentOut.
+                    __structuredAttrs = structuredAttrs;
                     requiredSystemFeatures = (orig.requiredSystemFeatures or [ ]) ++ [ "builder-rpc-v0" ];
                     __contentAddressed = true;
                     outputHashMode = "text";
@@ -388,7 +406,8 @@ stdenv0.override (
                       unset NIXGG_BYPASS
                     '' + (orig.preBuild or "");
                     postBuild = (orig.postBuild or "") + submitBuildTreeScript outerName;
-                  };
+                  }
+                  // nonexistentOut;
               in
               applyExtra extraBuildAttrs finalAttrs base;
 
@@ -414,7 +433,10 @@ stdenv0.override (
                 // {
                   phases = "ggRestorePhase checkPhase installPhase fixupPhase installCheckPhase distPhase";
                   dontUnpack = true;
-                  __structuredAttrs = false;
+                  # Honoured, not forced — same reasoning as the build
+                  # stage above. This stage owns the package's REAL
+                  # outputs, so it needs no placeholder.
+                  __structuredAttrs = structuredAttrs;
                   ggRestorePhase = ''
                     runHook preGgRestore
                     cp -a ${builtTree}/. "$NIX_BUILD_TOP/"
@@ -439,7 +461,19 @@ stdenv0.override (
                     # own `make install_sw` wrote straight to its literal
                     # `/nonexistent` prefix, never under $DESTDIR, until
                     # this was added.
-                    installFlags="''${installFlags-} DESTDIR=$DESTDIR"
+                    # installFlagsArray, not installFlags: under
+                    # __structuredAttrs `installFlags` is a bash ARRAY, and
+                    # assigning a scalar to an array name writes element 0
+                    # — which silently welds this onto the package's first
+                    # real flag. nixpkgs' kernel sets INSTALL_PATH=$out
+                    # there, so `make install` received one token
+                    # "INSTALL_PATH=… DESTDIR=…" and died on `cp: target
+                    # 'DESTDIR=…': No such file or directory` — after a
+                    # 2h54m build that had otherwise fully succeeded.
+                    # setup.sh concatenates installFlagsArray in both
+                    # modes (concatTo, installPhase), and it is always a
+                    # plain array, so appending there is mode-independent.
+                    installFlagsArray+=( "DESTDIR=$DESTDIR" )
                     runHook postGgRestore
                   '';
                   installFlags = (orig.installFlags or "");

--- a/nix/splitStdenv.nix
+++ b/nix/splitStdenv.nix
@@ -122,6 +122,44 @@ let
   };
   inherit (shared) ggShimsOnPath submitBuildTreeScript outputPlaceholder;
 
+  # Replay the build stage's exports, gap-filling only: a variable the
+  # final stage already set always wins, so its own outputs and
+  # stdenv-managed state cannot be clobbered. Splitting one
+  # mkDerivation across two derivations splits the shell too, and
+  # packages routinely export in one stage and read in a later one.
+  ggRestoreEnv = ''
+    if [ -f "$NIX_BUILD_TOP/.gg-env" ]; then
+      while IFS= read -r ggLine; do
+        case "$ggLine" in
+          "declare -x "*) ;;
+          *) continue ;;
+        esac
+        ggKV=''${ggLine#declare -x }
+        ggName=''${ggKV%%=*}
+        case "$ggName" in
+          PATH|PWD|OLDPWD|HOME|SHLVL|_) continue ;;
+          TMP|TMPDIR|TEMP|TEMPDIR) continue ;;
+          NIX_BUILD_TOP|NIX_STORE|NIX_BUILD_CORES|NIX_LOG_FD) continue ;;
+          out|outputs) continue ;;
+          NIXGG_*) continue ;;
+          # Phase control. Derivation attributes are exported like any
+          # other variable, so the build stage's own `dontInstall = true`
+          # arrives here as dontInstall=1 — and the final stage, which
+          # never sets it, would gap-fill it and then SKIP ITS OWN
+          # installPhase. That failure is silent: the builder exits 0
+          # having run nothing, and Nix reports only "failed to produce
+          # output path". Same hazard for dontFixup/doCheck/doDist and
+          # for the phase list itself.
+          dont*|do[A-Z]*|phases|*Phase|*Phases) continue ;;
+        esac
+        # Gap-fill only: never override what the final stage decided.
+        if [ -z "''${!ggName+x}" ]; then
+          eval "export $ggKV"
+        fi
+      done < "$NIX_BUILD_TOP/.gg-env"
+    fi
+  '';
+
   # extraAttrs runs first as a shared baseline; the role-specific hatch
   # composes on top and wins — see extraAttrs's own docstring above.
   applyExtra = hatch: finalAttrs: base: hatch finalAttrs (extraAttrs finalAttrs base);
@@ -457,6 +495,7 @@ stdenv0.override (
                     cp -a ${builtTree}/. "$NIX_BUILD_TOP/"
                     chmod -R u+w "$NIX_BUILD_TOP"
                     cd "$NIX_BUILD_TOP/$(cat "$NIX_BUILD_TOP/.gg-cwd")"
+                    ${ggRestoreEnv}
                     export DESTDIR="$NIX_BUILD_TOP/.gg-destdir"
                     # `export DESTDIR` alone is not enough: some packages'
                     # own Configure/Makefile (openssl's

--- a/nix/splitStdenv.nix
+++ b/nix/splitStdenv.nix
@@ -102,6 +102,11 @@
   # headers; with it, a fraction of that. Threaded into ggShimsOnPath's
   # NIXGG_SHARED_STAGE — see internal/stage's SourcesShared.
   sharedStaging ? false,
+  # Subtrees whose build reads object BYTES inline, which no derivation
+  # can model. The shims pass work under them straight through — see
+  # internal/mode. Threaded into ggShimsOnPath's
+  # NIXGG_PASSTHROUGH_PATHS.
+  passthroughPaths ? [ ],
 }:
 
 let
@@ -122,6 +127,7 @@ let
       coreutils
       gcc
       gnumake
+      passthroughPaths
       sharedStaging
       system
       ;

--- a/nix/splitStdenv.nix
+++ b/nix/splitStdenv.nix
@@ -97,6 +97,11 @@
   # filtering — always safe). Same shape as the old configureCacheStdenv
   # param — see nix/configureSrcFilter.nix.
   configureSrcFilter ? null,
+  # Stage each TU as a symlink farm into per-file store objects rather
+  # than copying. Without it a kernel stages ~150 GB of duplicated
+  # headers; with it, a fraction of that. Threaded into ggShimsOnPath's
+  # NIXGG_SHARED_STAGE — see internal/stage's SourcesShared.
+  sharedStaging ? false,
 }:
 
 let
@@ -117,6 +122,7 @@ let
       coreutils
       gcc
       gnumake
+      sharedStaging
       system
       ;
   };

--- a/nix/splitStdenv.nix
+++ b/nix/splitStdenv.nix
@@ -363,7 +363,14 @@ stdenv0.override (
                     # (and any hook attached to it) entirely, so
                     # restoring the configure stage's tree needs its own
                     # always-run phase name instead.
-                    phases = "unpackPhase patchPhase ggRestorePhase buildPhase";
+                    # ggSubmitPhase is named explicitly here because
+                    # setup.sh only splices postPhases when `phases` is
+                    # UNSET. The configureStage == null path below leaves
+                    # it unset and gets the submit via postPhases; this
+                    # branch would silently drop it, and a build that
+                    # submits nothing fails with Nix's opaque "failed to
+                    # submit output path for 'out'".
+                    phases = "unpackPhase patchPhase ggRestorePhase buildPhase ggSubmitPhase";
                     ggRestorePhase = configureStage.restorePhase;
                   }
                   # Extra outputs (bin/dev/man/...) are plain env vars
@@ -405,7 +412,15 @@ stdenv0.override (
                     preBuild = ''
                       unset NIXGG_BYPASS
                     '' + (orig.preBuild or "");
-                    postBuild = (orig.postBuild or "") + submitBuildTreeScript outerName;
+                    # A real phase, not a postBuild hook: postBuild only
+                    # runs if the package's buildPhase calls runHook, and
+                    # many hand-written ones do not (nixpkgs' own
+                    # linux-config among them) — those built fine,
+                    # submitted nothing, and failed with Nix's opaque
+                    # "failed to submit output path for 'out'".
+                    # postPhases is spliced on unconditionally by setup.sh.
+                    postPhases = (lib.toList (orig.postPhases or [ ])) ++ [ "ggSubmitPhase" ];
+                    ggSubmitPhase = submitBuildTreeScript outerName;
                   }
                   // nonexistentOut;
               in

--- a/nix/splitStdenv.nix
+++ b/nix/splitStdenv.nix
@@ -496,6 +496,17 @@ stdenv0.override (
                     chmod -R u+w "$NIX_BUILD_TOP"
                     cd "$NIX_BUILD_TOP/$(cat "$NIX_BUILD_TOP/.gg-cwd")"
                     ${ggRestoreEnv}
+
+                    # The final stage needs the shims reachable but
+                    # inert: build systems bake absolute tool paths at
+                    # configure time (cmake does; a caller can via
+                    # makeFlags), so those paths get invoked here whether
+                    # or not we planned for it. Without the env the shim
+                    # cannot build its config and exits non-zero. Nothing
+                    # is left to accelerate, so BYPASS makes each one
+                    # exec the real tool.
+                    export NIXGG_BYPASS=1
+                    ${ggShimsOnPath knownStorePathsJSON}
                     export DESTDIR="$NIX_BUILD_TOP/.gg-destdir"
                     # `export DESTDIR` alone is not enough: some packages'
                     # own Configure/Makefile (openssl's

--- a/tests/kernel-passthrough.sh
+++ b/tests/kernel-passthrough.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Guards the kernel's passthrough-path list.
+#
+# WHY THIS EXISTS
+#
+# The subtrees a kernel builds by reading object bytes inline — realmode,
+# libstub, the vDSO, purgatory, scripts/mod, test_fortify — used to be
+# compiled into internal/mode, where a 2ms unit test in a separate file
+# caught any accidental change to the list. Moving them to a
+# `passthroughPaths` parameter fixed a real layering problem (Linux-,
+# x86- and version-specific knowledge inside a general-purpose tool) but
+# lost that guard: internal/mode's tests now SUPPLY the list before
+# asserting on it, so they pin the matching semantics and nothing else.
+# Asserting against your own input cannot catch a dropped entry.
+#
+# Without this script, deleting an entry from tests/kernel/kernel.nix
+# fails nothing until a multi-hour kernel build dies at the final vmlinux
+# link with dozens of undefined references — a message that names neither
+# the list nor the subtree. That is exactly how the thin-archive bug
+# presented, and it took a day to trace.
+#
+# So: check the list by EVALUATION only. No build, no store writes, ~1s.
+#
+# It reads the value out of the real phase-1 derivation rather than
+# re-reading a Nix list, so it also proves the plumbing — that
+# passthroughPaths actually reaches the build as NIXGG_PASSTHROUGH_PATHS.
+# A list compared against a list would pass even if the parameter were
+# silently dropped between splitStdenv and the shims.
+#
+# This is a change-detector, deliberately. Whether these six are the
+# RIGHT subtrees is only answerable by tests/kernel/boot-test.nix. What
+# this catches is the accident.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+nixgg_root="$(cd "$here/.." && pwd)"
+PATCHED_NIX="${PATCHED_NIX:-$nixgg_root/.patched-nix}"
+
+if [[ ! -x "$PATCHED_NIX/bin/nix" ]]; then
+  echo "SKIP: no patched nix at $PATCHED_NIX" >&2
+  exit 0
+fi
+
+# Needs its own store even though it never builds: the daemon store
+# rejects a text-hashed derivation output, so instantiating the kernel
+# fails at EVALUATION with a dynamic-derivations error that does not
+# mention the store. Only .drv files land here, so it stays tiny.
+STORE="${PASSTHROUGH_STORE:-/tmp/nixgg-passthrough-store}"
+mkdir -p "$STORE"
+
+export NIX_CONFIG="
+experimental-features = nix-command flakes ca-derivations dynamic-derivations
+store = local?root=$STORE
+"
+
+cd "$nixgg_root"
+
+drv=$("$PATCHED_NIX/bin/nix" eval --impure --raw \
+  --expr '(import ./tests/kernel/kernel.nix {}).drvPath' 2>/dev/null)
+if [[ -z "$drv" ]]; then
+  echo "FAIL: tests/kernel/kernel.nix did not evaluate" >&2
+  exit 1
+fi
+
+# -r walks the derivation closure, which is where phase 1 lives: the
+# kernel package itself is phase 2, and the shim env is set in phase 1's
+# postPatch.
+got=$("$PATCHED_NIX/bin/nix" derivation show -r "$drv" 2>/dev/null \
+  | tr -d '\\' | grep -o "NIXGG_PASSTHROUGH_PATHS='\[[^]]*\]'" | head -1)
+
+if [[ -z "$got" ]]; then
+  echo "FAIL: NIXGG_PASSTHROUGH_PATHS is not exported into the kernel build." >&2
+  echo "      passthroughPaths is being dropped somewhere between" >&2
+  echo "      tests/kernel/kernel.nix and splitStdenv's shim env." >&2
+  exit 1
+fi
+
+expected=(
+  "arch/x86/realmode/"
+  "drivers/firmware/efi/libstub/"
+  "arch/x86/entry/vdso/"
+  "arch/x86/purgatory/"
+  "scripts/mod/"
+  "/test_fortify/"
+)
+
+missing=0
+for want in "${expected[@]}"; do
+  if [[ "$got" != *"\"$want\""* ]]; then
+    echo "FAIL: missing passthrough path: $want" >&2
+    missing=1
+  fi
+done
+
+# An empty element substring-matches EVERY path, so one stray "" passes
+# the entire build through. That surfaces as nixgg accelerating nothing
+# rather than as an error, which is far worse than a hard failure.
+# internal/mode drops them defensively; catch it here too, where the
+# message can say what happened.
+if [[ "$got" == *'""'* ]]; then
+  echo "FAIL: empty string in passthroughPaths — it matches every path and" >&2
+  echo "      would pass the whole build through silently." >&2
+  missing=1
+fi
+
+if [[ $missing -ne 0 ]]; then
+  echo >&2
+  echo "got: $got" >&2
+  exit 1
+fi
+
+echo "OK: kernel passthroughPaths reaches the build, all ${#expected[@]} entries present"

--- a/tests/kernel/README.md
+++ b/tests/kernel/README.md
@@ -1,0 +1,98 @@
+# Kernel fixtures
+
+A full Linux kernel built through nixgg's dynamic derivations, and a
+NixOS VM test that boots it.
+
+**These are not run by `tests/drv-equivalence.sh`, `tests/smoke.sh`, or
+`nix flake check`, and nothing in `flake.nix` references them.** They are
+run by hand.
+
+## Why they are opt-in
+
+Cost, not confidence. A cold `kernel.nix` realises 29,268 derivations.
+Phase 1 logs 19,167 compiles, 7,300 objtool steps, 2,065 partial links,
+797 archives, 29 objcopy rewrites, 14 links and 3 rustc crates — a few
+dozen of those bail to passthrough rather than becoming derivations,
+which is why the parts total slightly more than the whole. Measured end
+to end: 2h54m on 32 cores at `--max-jobs 128`. `boot-test.nix` then
+builds a NixOS closure on top and runs QEMU (1m14s once the kernel is
+built); kernel and boot closure together came to roughly 31 GB of
+filesystem. The regular test scripts are meant to run in minutes on
+every change.
+
+That is also why they live here rather than in `flake.nix`: an attribute
+in `packages` would be picked up by `nix flake check` and by anyone
+running `nix flake show`.
+
+## Running them
+
+Both need the builder-rpc-capable nix built by this flake — the system
+nix will not do — plus the dynamic-derivation experimental features and
+`--impure` (the default `nixgg` argument calls
+`builtins.getFlake` on a path).
+
+They also need a store that is **not** the daemon store, which rejects
+text-hashed derivation outputs, and one on a filesystem with room —
+budget well over 100 GB from cold.
+
+Build the kernel:
+
+    ./.patched-nix/bin/nix build --impure --no-link -L \
+      --store 'local?root=/path/to/scratch/store' \
+      --extra-experimental-features "ca-derivations dynamic-derivations configurable-impure-env" \
+      --extra-system-features builder-rpc-v0 \
+      --expr '(import ./tests/kernel/kernel.nix {})'
+
+Boot it (same flags):
+
+    ./.patched-nix/bin/nix build --impure --no-link -L \
+      --store 'local?root=/path/to/scratch/store' \
+      --extra-experimental-features "ca-derivations dynamic-derivations configurable-impure-env" \
+      --extra-system-features builder-rpc-v0 \
+      --expr '(import ./tests/kernel/boot-test.nix {})'
+
+The boot test additionally needs KVM: `/dev/kvm` accessible, and `kvm`
+plus `nixos-test` in the daemon's `system-features`.
+
+## Things that will bite you
+
+- **The daemon store rejects text-hashed outputs.** Without
+  `--store 'local?root=…'` the build fails at evaluation with a
+  dynamic-derivations error that does not name the store as the cause.
+
+- **Experimental features must be on the command line or in
+  `NIX_CONFIG`.** The flake's own `nixConfig` is read too late — the
+  feature set is frozen before it applies, so `builtins.outputOf` is
+  already missing by then.
+
+- **`fs.mount-max` may need raising, but the default was enough here.**
+  Nix bind-mounts an input closure into each sandbox, so a large final
+  closure can exhaust it; the symptom is `bind mount … failed: No space
+  left on device` while the disk has plenty free. An earlier revision of
+  this file said the default (100000) had to be raised for a kernel.
+  Full cold builds have since completed at the default — including one
+  whose single assembly derivation took every stub as a direct input —
+  so treat this as a symptom to recognise rather than a step to perform.
+
+- **`MAX_ARG_STRLEN` is not the constraint it looks like.** It is a
+  compile-time kernel constant and cannot be raised, but the assembly
+  derivation never puts its build script in `argv`:
+  `assemble.Build` sets `passAsFile`, so the script reaches the builder
+  as a file. Scripts naming tens of thousands of stubs are fine.
+
+- **Watch liveness by log growth, not by `pgrep`.** A pattern like
+  `pgrep -f mybuild` matches the checking command's own argv and will
+  cheerfully report a dead build as running.
+
+## What the boot test proves
+
+1. The kernel reaches `multi-user.target` — init ran, userland is up.
+2. `uname -r` matches `kernel.modDirVersion` — it is this kernel, not a
+   fallback that a misconfigured `boot.kernelPackages` silently
+   substituted.
+3. `modprobe loop` loads and `losetup -f` works — `modules_install`,
+   `depmod` and `modpost` produced a coherent tree, not just files.
+
+Point 3 is the one that earns its cost. The thin-archive bug produced a
+kernel that passed every structural check while missing whole subtrees;
+"it built" is not evidence.

--- a/tests/kernel/boot-test.nix
+++ b/tests/kernel/boot-test.nix
@@ -1,0 +1,78 @@
+# Does the kernel nixgg built actually BOOT?
+#
+# NOT wired into tests/drv-equivalence.sh, tests/smoke.sh, or the flake's
+# checks. It depends on ./kernel.nix (hours from cold) and then builds a
+# NixOS closure and runs QEMU. See ./README.md.
+#
+#
+# WHY A BOOT TEST AND NOT MORE STRUCTURAL CHECKS
+#
+# Structural checks — correct bzImage headers, a complete symbol table,
+# the expected module count — rule out obvious corruption and nothing
+# else. The failure modes this design actually produces are subtler: a
+# dropped object, a mis-ordered archive member, a stale .cmd file. Each
+# leaves an image that passes every structural check and dies at boot.
+#
+# That is not hypothetical. The thin-archive bug (see internal/shim/
+# thinar.go) silently dropped three whole subtrees while producing a
+# vmlinux.o of plausible size with a valid ELF header. Only the final
+# link caught it, and only because 49 symbols happened to be referenced.
+# A quieter version of the same bug would have produced a kernel that
+# built, installed, and panicked.
+#
+# So: boot it, and make it prove three things.
+{
+  nixgg ? builtins.getFlake (toString ../..),
+  system ? builtins.currentSystem,
+  kernel ? import ./kernel.nix { inherit nixgg system; },
+}:
+
+let
+  pkgs = nixgg.inputs.nixpkgs.legacyPackages.${system};
+
+  # linuxPackagesFor wants a real kernel derivation — modDirVersion,
+  # passthru, the $dev and $modules outputs. That is why kernel.nix
+  # leaves nixpkgs' installPhase alone.
+  kernelPackages = pkgs.linuxPackagesFor kernel;
+in
+pkgs.testers.runNixOSTest {
+  name = "nixgg-kernel-boots";
+
+  nodes.machine =
+    { ... }:
+    {
+      boot.kernelPackages = kernelPackages;
+
+      # Keep the VM minimal so a kernel problem surfaces as a kernel
+      # problem, rather than as some unrelated unit failing to start.
+      virtualisation.memorySize = 2048;
+      virtualisation.graphics = false;
+    };
+
+  testScript = ''
+    machine.start()
+
+    # 1. Userland came up at all: init ran and systemd reached its
+    #    default target.
+    machine.wait_for_unit("multi-user.target")
+
+    # 2. It is OUR kernel. Compared against the version the derivation
+    #    declares rather than a literal, so this cannot pass by matching
+    #    a stale string — or by silently booting a fallback kernel, which
+    #    is exactly what a misconfigured boot.kernelPackages would do.
+    want = "${kernel.modDirVersion}"
+    got = machine.succeed("uname -r").strip()
+    assert got == want, f"running kernel is {got!r}, expected {want!r}"
+
+    # 3. The module tree is coherent. Loading a module exercises
+    #    modules_install, depmod's modules.dep and modpost's symbol
+    #    versioning together, and losetup proves the module actually
+    #    works rather than merely loading. This is the check that would
+    #    have caught the thin-archive bug: "it built" is not evidence.
+    machine.succeed("modprobe loop")
+    machine.succeed("lsmod | grep -q '^loop'")
+    machine.succeed("losetup -f")
+
+    print(machine.succeed("uname -a"))
+  '';
+}

--- a/tests/kernel/kernel.nix
+++ b/tests/kernel/kernel.nix
@@ -1,0 +1,227 @@
+# A full Linux kernel built through nixgg's dynamic derivations.
+#
+# NOT wired into tests/drv-equivalence.sh, tests/smoke.sh, or the flake's
+# checks, and deliberately so: a from-scratch run realises ~29,000
+# derivations and takes hours. See ./README.md for how to run it.
+#
+#
+# WHY THE TWO-PHASE SHAPE IS FORCED
+#
+# `make vmlinux_o` cannot work in one phase. Makefile:1236:
+#
+#   cmd_ar_vmlinux.a = rm -f $@;                                       \
+#     $(AR) cDPrST $@ $(KBUILD_VMLINUX_OBJS);                          \
+#     $(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep ...)
+#
+# One recipe creates vmlinux.a, then lists it with `ar t`, pipes the
+# member names through sed/grep, and reorders members in place. It
+# inspects its own output inline — the same undeferrable shape as
+# realmode and libstub, but on the artifact that aggregates the whole
+# kernel, so it cannot be carved out either: passing it through needs
+# real inputs, and its inputs are every built-in.a in the tree.
+#
+# So vmlinux.a is where deferral has to end. Phase 1 models every object
+# and per-directory archive; phase 2 runs the final assembly against the
+# outputs Nix has realised.
+{
+  # The nixgg flake. The default resolves this repo, which needs
+  # --impure because getFlake wants a real path.
+  nixgg ? builtins.getFlake (toString ../..),
+  system ? builtins.currentSystem,
+  # Stage each TU as a symlink farm into per-file store objects rather
+  # than copying. Without it a kernel stages ~150 GB of duplicated
+  # headers; with it, a fraction of that.
+  sharedStaging ? true,
+}:
+
+let
+  pkgs = nixgg.inputs.nixpkgs.legacyPackages.${system};
+  splitStdenv = nixgg.packages.${system}.splitStdenv;
+  nixggBin = nixgg.packages.${system}.nixgg-bin;
+
+  # The kernel needs the UNWRAPPED ld — common-flags.nix notes the
+  # wrapper breaks it — so hand the shim that exact binary rather than
+  # letting it guess from the compiler directory.
+  ldReal = "${pkgs.stdenv.cc.bintools.bintools}/bin/${pkgs.stdenv.cc.targetPrefix}ld";
+
+  # splitStdenv wraps every derivation built with it, including the
+  # kernel's own dependencies. Only reshape the kernel itself.
+  onlyKernel = g: finalAttrs: old: if (old.pname or "") == "linux" then g finalAttrs old else old;
+
+  # Every top-level directory that produces a built-in.a, plus arch/x86.
+  # Phase 1 builds these rather than `vmlinux`, stopping short of the
+  # vmlinux.a step described above.
+  dirs = [
+    "init/"
+    "usr/"
+    "kernel/"
+    "certs/"
+    "mm/"
+    "fs/"
+    "ipc/"
+    "security/"
+    "crypto/"
+    "block/"
+    "io_uring/"
+    "rust/"
+    "drivers/"
+    "sound/"
+    "net/"
+    "lib/"
+    "virt/"
+    "arch/x86/"
+  ];
+
+  # nixpkgs passes absolute tool paths precisely to defeat PATH
+  # interposition, so every shim needs naming explicitly — putting them
+  # on PATH accomplishes nothing here. Each entry cost a failed run to
+  # learn; omitting OBJCOPY, for instance, silently accelerates nothing
+  # while looking like it works.
+  #
+  # `objtool` is lowercase and assigned with `:=` in scripts/Makefile.lib
+  # with no `override`, so a command-line assignment wins. Safe to
+  # override: the rule that BUILDS objtool keys on `tools/objtool` and a
+  # separate `objtool_O`, not on `$(objtool)`.
+  shimFlags = [
+    "CC=${nixggBin}/shims/gcc"
+    "AR=${nixggBin}/shims/ar"
+    "objtool=${nixggBin}/shims/objtool"
+    "LD=${nixggBin}/shims/ld"
+    "OBJCOPY=${nixggBin}/shims/objcopy"
+  ];
+
+  # The shims need the real binaries to store-add. objtool is built by
+  # kbuild during `make prepare`, so it exists only once configurePhase
+  # has run — hence a hook rather than an attribute.
+  realToolEnv = ''
+    export NIXGG_REAL_OBJTOOL="$buildRoot/tools/objtool/objtool"
+    export NIXGG_REAL_LD="${ldReal}"
+    export NIXGG_REAL_OBJCOPY="${pkgs.stdenv.cc}/bin/objcopy"
+
+    # Variables the Rust crates read at COMPILE time, which have to
+    # travel into each crate's derivation — see internal/shim/rustcenv.go
+    # for why they cannot be inferred.
+    #
+    #   OBJTREE       rust/{kernel,bindings,uapi} do
+    #                 include!(concat!(env!("OBJTREE"), "/rust/…")) to
+    #                 reach bindgen's generated bindings. The shim
+    #                 rewrites it onto the staged tree.
+    #   RUST_MODFILE  the `module!` proc macro reads it to name the
+    #                 module; every driver written in Rust expands it.
+    #   RUSTC_BOOTSTRAP  Makefile:627 exports it so a stable rustc
+    #                 accepts the -Z flags kbuild relies on. Without it
+    #                 the derivation's rustc rejects them outright:
+    #                 "the option `Z` is only accepted on the nightly
+    #                 compiler".
+    export NIXGG_RUSTC_ENV='["OBJTREE","RUST_MODFILE","RUSTC_BOOTSTRAP"]'
+  '';
+in
+pkgs.linux.override {
+  stdenv = splitStdenv {
+    stdenv = pkgs.stdenv;
+    splitAtBuild = true;
+    inherit sharedStaging;
+
+    # Subtrees whose build reads object BYTES inline, which no derivation
+    # can model because the answer is needed before make continues. They
+    # run as ordinary passthrough work instead.
+    #
+    # This list is why the parameter exists: every entry is specific to
+    # Linux, most are specific to x86, and all are specific to a kernel
+    # version. They used to be compiled into internal/mode.
+    #
+    #   realmode      cmd_pasyms: `$(NM) $(real-prereqs) | sed > $@`
+    #                 produces a generated HEADER, not an artifact.
+    #   libstub       cmd_stubcopy pipes objdump to grep and calls
+    #                 /bin/false on a match — it decides whether to FAIL
+    #                 the build from the text.
+    #   vdso          links a shared object with its own linker script;
+    #                 shim.LD models only `ld -r`.
+    #   purgatory     re-links its own output as purgatory.chk purely to
+    #                 verify it, and the check link meets the modelled .ro.
+    #   scripts/mod   runs its own tool over empty.o (`mk_elfconfig <
+    #                 scripts/mod/empty.o`). Whether that lands in
+    #                 configure (harmless) or build (fatal) depends on
+    #                 when make schedules prepare0 — observed both ways.
+    #   test_fortify  compiles code that MUST NOT compile and greps the
+    #                 diagnostic; a derivation would turn the expected
+    #                 error into a dead build.
+    #
+    # Together well under 1% of a kernel's translation units.
+    passthroughPaths = [
+      "arch/x86/realmode/"
+      "drivers/firmware/efi/libstub/"
+      "arch/x86/entry/vdso/"
+      "arch/x86/purgatory/"
+      "scripts/mod/"
+      "/test_fortify/"
+    ];
+
+    extraBuildAttrs = onlyKernel (
+      finalAttrs: old:
+      old
+      // {
+        buildFlags = [ "KBUILD_BUILD_VERSION=1-NixOS" ] ++ dirs;
+        makeFlags = (old.makeFlags or [ ]) ++ shimFlags;
+        preBuild = (old.preBuild or "") + realToolEnv;
+      }
+    );
+
+    extraInstallAttrs = onlyKernel (
+      finalAttrs: old:
+      old
+      // {
+        # Phase 2 keeps the SAME makeFlags, shim paths included. That is
+        # deliberate: kbuild's if_changed compares the command line
+        # recorded in each .cmd file against the command it would run
+        # now, and phase 1 recorded the shim paths. Dropping them here
+        # would make every object look stale and rebuild the kernel.
+        #
+        # splitStdenv sets NIXGG_BYPASS=1 for the final stage, so the shims exec
+        # the real tools: the command text matches while the work is
+        # real, which is what the final assembly needs.
+        makeFlags = (old.makeFlags or [ ]) ++ shimFlags;
+
+        # Deliberately NOT an installPhase override.
+        #
+        # Earlier revisions of this file overrode it and copied artifacts
+        # by hand. That yields a directory of loose files — fine for
+        # inspecting a bzImage, useless as a package. nixpkgs' own
+        # install is what makes this a real kernel: `make install` with
+        # INSTALL_PATH=$out INSTALL_MOD_PATH=$modules, plus hooks that
+        # lay out $modules/lib/modules/<version>/, run depmod, and
+        # populate $dev. linuxPackagesFor and the NixOS module system
+        # depend on exactly that shape, so ./boot-test.nix cannot boot
+        # anything built otherwise.
+        #
+        # Phase 2's phases are `ggRestorePhase checkPhase installPhase
+        # …` with no buildPhase, so the remaining kernel build happens
+        # here, before the stock install.
+        preInstall =
+          realToolEnv
+          + ''
+            # Build the stock target list, not a subset. bzImage pulls in
+            # the final vmlinux link (linker script plus both kallsyms
+            # passes) then arch/x86/boot's compress-and-wrap; modules
+            # covers the ~7,300 CONFIG=m .ko links, each needing modpost.
+            #
+            # These are precisely the stages phase 1 could not model:
+            # arch/x86/boot, realmode and purgatory all run nm/objdump
+            # over their own output and feed the TEXT to the next step,
+            # which is why they are carveouts in mode.For. Here they run
+            # as ordinary passthrough work against the objects the
+            # derivations produced — the point of the two-phase split.
+            #
+            # scripts_gdb looks droppable and is not: nixpkgs' postInstall
+            # copies scripts/gdb/linux/constants.py, which only that
+            # target generates, so a shorter list installs a bzImage and
+            # a full module tree and then dies on
+            #   cp: cannot stat 'scripts/gdb/linux/constants.py'
+            make "''${makeFlags[@]}" -j"$NIX_BUILD_CORES" \
+              bzImage vmlinux scripts_gdb modules
+          ''
+          + (old.preInstall or "");
+      }
+    );
+  };
+}

--- a/tests/shared-closure.sh
+++ b/tests/shared-closure.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Regression test for shared (symlink-farm) staging.
+#
+# With sharedStaging, a staged source tree holds no file contents — every
+# entry is a symlink into a content-addressed store object, so the same
+# header is stored once instead of once per translation unit — several
+# times smaller on examples/gcc, and the ratio grows with TU count.
+#
+# That makes the farm's dependency on its headers INDIRECT: the NAR contains
+# target path strings, not bytes. Nix only turns those strings into real
+# dependency edges because the shim store-adds farms with `--scan`, which
+# records symlink targets as references.
+#
+# What happens if --scan is dropped is worth being precise about, because
+# the obvious guess is wrong. It does NOT produce a farm that works locally
+# and breaks on a fresh machine: a compile derivation's sandbox mounts only
+# the closure of its inputs, so unreferenced targets are absent even in the
+# store that just created them, and the compile fails at once with
+#
+#   cc1plus: fatal error: util.cc: No such file or directory
+#
+# Verified by mutation — removing --scan from StoreAddScan fails the hello
+# build immediately. So the reference edge is enforced by Nix itself, not
+# merely relied upon.
+#
+# The gap this test fills is therefore narrower, and real: NOTHING ELSE in
+# the suite turns sharedStaging on. drv-equivalence and smoke both run with
+# it off (it is opt-in precisely because flipping it changes every drv
+# hash), so absent this script a regression anywhere in the shared-staging
+# path is invisible. It also turns an opaque missing-header error into a
+# named diagnosis.
+#
+# It has to build for real: `nix store add --scan` only works inside a
+# recursive-nix derivation builder, so no Go test can reach it. The hashing
+# half of the scheme — that a header edit changes the farm's hash — is
+# pinned by TestSourcesSharedHashTracksContent, which can.
+#
+# Env knobs:
+#   SHARED_STORE   root of the store to build in
+#                  (default /tmp/nixgg-shared-store; NOT drv-equivalence's
+#                  ALT_STORE, which that script wipes on every run)
+#   PATCHED_NIX    path to a builder-rpc-v0-capable nix
+#   EXAMPLE        example to build (default hello)
+#   KEEP_STORE=1   don't wipe the store at start
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+nixgg_root="$(cd "$here/.." && pwd)"
+
+SHARED_STORE="${SHARED_STORE:-/tmp/nixgg-shared-store}"
+PATCHED_NIX="${PATCHED_NIX:-$nixgg_root/.patched-nix}"
+EXAMPLE="${EXAMPLE:-hello}"
+
+if [[ ! -x "$PATCHED_NIX/bin/nix" ]]; then
+  echo "==> building patched nix (one-time; substituted from cache)" >&2
+  nix build --no-eval-cache "$nixgg_root#patched-nix" -o "$PATCHED_NIX" >&2 || {
+    echo "failed to build $nixgg_root#patched-nix" >&2
+    exit 2
+  }
+fi
+nix_bin="$PATCHED_NIX/bin/nix"
+
+if [[ "${KEEP_STORE:-}" != "1" ]]; then
+  chmod -R u+w "$SHARED_STORE" 2>/dev/null || true
+  rm -rf "$SHARED_STORE"
+fi
+mkdir -p "$SHARED_STORE"
+
+export NIX_REMOTE=""
+export NIX_CONFIG="
+experimental-features = nix-command flakes ca-derivations dynamic-derivations configurable-impure-env
+extra-system-features = builder-rpc-v0
+store = local?root=$SHARED_STORE
+"
+
+if [[ ! -e "$SHARED_STORE/$(readlink -f "$PATCHED_NIX")" ]]; then
+  "$nix_bin" copy --from daemon --to "local?root=$SHARED_STORE" \
+      --no-check-sigs "$(readlink -f "$PATCHED_NIX")" >/dev/null 2>&1 || true
+fi
+
+# `.#<name>-shared` is the shipped example definition with sharedStaging
+# flipped on (see flake.nix), so this tests the same build everything else
+# does rather than a recipe written for the test.
+echo "==> building $EXAMPLE-shared into $SHARED_STORE" >&2
+"$nix_bin" build --no-eval-cache --no-link "$nixgg_root#$EXAMPLE-shared" >&2
+
+# ---------------------------------------------------------------
+# Inspect every staged farm.
+#
+# Identify them structurally rather than by name, so a naming change
+# doesn't silently skip the check — but the discriminator has to be
+# EXACT, not merely sufficient. "Store path containing symlinks" is not:
+# it matches ncurses (1060 links), glibc, coreutils and most of stdenv,
+# whose references are of course correct, so the check passed on nixpkgs
+# paths while never looking at a farm at all.
+#
+# A staged farm is the only thing in the store with symlinks and ZERO
+# regular files — that is precisely what shared staging produces. On
+# hello this selects exactly the two TU trees (main, util) and nothing
+# else.
+# ---------------------------------------------------------------
+store_dir="$SHARED_STORE/nix/store"
+farms=0
+links=0
+bad=0
+
+while IFS= read -r farm; do
+  [[ -n "$(find "$farm" -type f -print -quit 2>/dev/null)" ]] && continue
+  mapfile -t targets < <(find "$farm" -type l -exec readlink {} \; 2>/dev/null \
+    | grep '^/nix/store/' | sort -u)
+  [[ ${#targets[@]} -eq 0 ]] && continue
+
+  farms=$((farms + 1))
+  echo "  farm $(basename "$farm") (${#targets[@]} targets)" >&2
+  logical="/nix/store/$(basename "$farm")"
+  mapfile -t closure < <("$nix_bin" path-info -r "$logical" 2>/dev/null)
+
+  for t in "${targets[@]}"; do
+    links=$((links + 1))
+    # A target may itself be a symlink chain; compare on the store path
+    # root, which is what references record.
+    root="/nix/store/$(echo "${t#/nix/store/}" | cut -d/ -f1)"
+    if ! printf '%s\n' "${closure[@]}" | grep -qxF "$root"; then
+      echo "FAIL: $logical symlinks to $root but does not reference it" >&2
+      bad=$((bad + 1))
+    fi
+  done
+done < <(find "$store_dir" -maxdepth 1 -mindepth 1 -type d 2>/dev/null)
+
+echo
+if [[ $farms -eq 0 ]]; then
+  echo "FAIL: no staged farms found in $SHARED_STORE" >&2
+  echo "      sharedStaging did not take effect, so this test proved nothing." >&2
+  exit 1
+fi
+
+echo "checked $farms staged farms, $links symlink targets"
+if [[ $bad -gt 0 ]]; then
+  echo "FAIL: $bad symlink target(s) missing from their farm's closure" >&2
+  echo "      Substituting these farms onto a fresh machine yields dangling" >&2
+  echo "      symlinks. Check that StoreAddScan still passes --scan." >&2
+  exit 1
+fi
+echo "OK: every staged farm references all of its symlink targets"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -61,6 +61,7 @@ QUICK=(
   "fmt|lib/libfmt.a|-"
   "lua|bin/lua|%s -v"
   "gcc|lib/libiberty.a|-"
+  "rustc|lib/libapp.a|-"
   "mosh|bin/mosh-server|%s --version"
   "thin-archive|bin/thin-archive|%s"
 )

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -65,6 +65,16 @@ QUICK=(
   "thin-archive|bin/thin-archive|%s"
 )
 SLOW=(
+  # Not in QUICK because it needs the kernel's `dev` output — a ~3GB
+  # closure — which is a poor fit for a set advertised as "cheap by
+  # default, ~2 min".
+  #
+  # The version in this path tracks linuxPackages.kernel.modDirVersion
+  # from the flake pin, so a `nix flake update` that bumps the kernel
+  # needs this string bumped too. Kept explicit rather than globbed
+  # because the whole point of the `want` column is to pin the exact
+  # FHS location, and depmod cares that it is lib/modules/<ver>/.
+  "kmod|lib/modules/6.18.41/extra/hello_mod.ko|-"
   "redis|bin/redis-server|%s --version"
   "ffmpeg|bin/ffmpeg_g|%s -version"
   "llvm|bin/llc|%s --version"


### PR DESCRIPTION
Build the full stock NixOS kernel using dynamic derivations and nixgg. Needed to add shims for partial links, objcopy, objtool, and rustc. Also added a vmtest that boots with this kernel, ensuring we didn't accidentally vibe the functionality away.

Mostly vibes. Needs cleanup

<details>
<summary>Claude Brainslop Dump</summary>

Teach nixgg enough to build a Linux kernel, and prove it boots.

Everything here came out of making one real workload work end to end. The
kernel is not the point — it is the forcing function: 29,268 derivations
in one build, and every gap it exposed was a gap for other projects too.

## What it adds

**Four new shims.** `ld -r` partial links, two-operand `objcopy`, an
in-place object rewriter (`objtool`), and `rustc` crate compiles. A
kernel needs all four; without any one of them the build silently stops
being accelerated rather than failing.

**Thin archives as inputs.** A thin archive (`ar T`) stores member
*paths*, not bytes, so storing one whole loses everything it points at —
silently, surfacing much later as undefined references at the final link.
Foreign thin archives are now expanded and their members depended on.
This complements the members-sidecar mechanism on master, which covers
archives nixgg itself produces; the two halves are disjoint.

**Caller-declared passthrough.** The subtrees that read object bytes
inline (realmode, libstub, vDSO, purgatory, `scripts/mod`,
`test_fortify`) are Linux-, x86- and version-specific. They used to be
compiled into `internal/mode`; they are now a `passthroughPaths`
parameter, so general-purpose code stops carrying kernel trivia.

**Shared staging.** Staging each TU as a symlink farm into per-file store
objects instead of copying. Header closures overlap heavily across TUs —
a kernel otherwise stages ~150 GB of duplicated headers.

**Four `splitStdenv` correctness fixes**, each found by a build that
produced no error worth reading: honour the package's own
`__structuredAttrs` rather than forcing it off; submit the build tree
from a real phase rather than a `postBuild` hook (hand-written
buildPhases that never call `runHook` submitted nothing and died on
Nix's opaque "failed to submit output path"); carry phase 1's exported
shell environment into the final stage; and keep the shims reachable but
inert there.

Plus smaller shim fixes — `-I` ordering, `.incbin` sources, dependency
files, empty archives, store-object name sanitisation — and four
fixtures: the kernel, its boot test, an out-of-tree kernel module, and
two Rust crates.

## Verification

Cold kernel build: **2h54m**, 29,268 derivations (~19.1k compiles, ~7.3k
objtool, ~2.1k partial links, ~800 archives, 29 objcopy, 3 rustc).

The boot test is what makes this evidence rather than a claim. It runs
the kernel under QEMU and asserts it reaches `multi-user.target`, that
`uname -r` matches `modDirVersion`, and that `modprobe loop` → `lsmod` →
`losetup -f` all work. That last one is the assertion that earns its
cost: the thin-archive bug produced a kernel that passed every structural
check while missing whole subtrees. "It built" is not evidence.

Both fixtures are opt-in and run by hand — not wired into `flake.nix`,
`nix flake check`, or the test scripts, which are meant to finish in
minutes. See `tests/kernel/README.md`.

Also green: `drv-equivalence` (all fixtures), both cutoff tests,
`shared-closure`, `kernel-passthrough`, and the smoke set.

## Notes

- Two smoke failures are reproducible on master and unrelated to this
  branch: `nix run .#ffmpeg` (the harness invokes it bare, which exits
  non-zero) and `llvm` (a real regression — `llvm-min-tblgen` fails to
  link with undefined `FoldingSetBase` symbols; the failing derivation
  hash is byte-identical from both trees). `internal/expr`'s two batch
  tests assume `PATH=/usr/bin`, which has no `mkdir` on NixOS.
- `tests/kernel/README.md`'s derivation count is updated to match the
  measurement above.

</details>